### PR TITLE
Rename ABA:997 rdf:label from root to mouse brain

### DIFF
--- a/ttl/hbp_abam_ontology.ttl
+++ b/ttl/hbp_abam_ontology.ttl
@@ -12047,7 +12047,7 @@ ABA:996 rdf:type owl:Class ;
 
 ABA:997 rdf:type owl:Class ;
 
-        rdfs:label "root"@en ;
+        rdfs:label "mouse brain"@en ;
 
         nsu:synonym "root"@en .
 


### PR DESCRIPTION
Rename ABA:997 rdf:label from root to mouse brain so that we can clearly know the species 
