### PR TITLE
updated ttl/hbp_abam_ontology.ttl to use MBA prefix instead of the old ABA prefix

### DIFF
--- a/ttl/hbp_abam_ontology.ttl
+++ b/ttl/hbp_abam_ontology.ttl
@@ -8,12044 +8,12044 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix nsu: <http://www.FIXME.org/nsupper#> .
-@prefix ABA: <http://api.brain-map.org/api/v2/data/Structure/> .
+@prefix MBA: <http://api.brain-map.org/api/v2/data/Structure/> .
 @base <http://www.hbp.FIXME.org/hbp_abam_ontology> .
 
 <http://www.hbp.FIXME.org/hbp_abam_ontology> rdf:type owl:Ontology ;
                 owl:imports <http://www.FIXME.org/nsupper> .
 
 
-ABA:1 rdf:type owl:Class ;
+MBA:1 rdf:type owl:Class ;
 
       rdfs:label "Tuberomammillary nucleus, ventral part"@en ;
 
       nsu:synonym "TMv"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:557 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:557 ] .
 
 
 
-ABA:10 rdf:type owl:Class ;
+MBA:10 rdf:type owl:Class ;
 
        rdfs:label "Superior colliculus, motor related, intermediate gray layer"@en ;
 
        nsu:synonym "SCig"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:294 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:294 ] .
 
 
 
-ABA:100 rdf:type owl:Class ;
+MBA:100 rdf:type owl:Class ;
 
         rdfs:label "Interpeduncular nucleus"@en ;
 
         nsu:synonym "IPN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:165 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:165 ] .
 
 
 
-ABA:1000 rdf:type owl:Class ;
+MBA:1000 rdf:type owl:Class ;
 
          rdfs:label "extrapyramidal fiber systems"@en ;
 
          nsu:synonym "eps"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1009 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1009 ] .
 
 
 
-ABA:1001 rdf:type owl:Class ;
+MBA:1001 rdf:type owl:Class ;
 
          rdfs:label "Lobule V"@en ;
 
          nsu:synonym "CUL5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:928 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:928 ] .
 
 
 
-ABA:1002 rdf:type owl:Class ;
+MBA:1002 rdf:type owl:Class ;
 
          rdfs:label "Primary auditory area"@en ;
 
          nsu:synonym "AUDp"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:247 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:247 ] .
 
 
 
-ABA:1003 rdf:type owl:Class ;
+MBA:1003 rdf:type owl:Class ;
 
          rdfs:label "corticopontine tract"@en ;
 
          nsu:synonym "cpt"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:1004 rdf:type owl:Class ;
+MBA:1004 rdf:type owl:Class ;
 
          rdfs:label "Ventral premammillary nucleus"@en ;
 
          nsu:synonym "PMv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:1005 rdf:type owl:Class ;
+MBA:1005 rdf:type owl:Class ;
 
          rdfs:label "Primary auditory area, layer 6b"@en ;
 
          nsu:synonym "AUDp6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:1006 rdf:type owl:Class ;
+MBA:1006 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, trunk, layer 1"@en ;
 
          nsu:synonym "SSp-tr1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:1007 rdf:type owl:Class ;
+MBA:1007 rdf:type owl:Class ;
 
          rdfs:label "Simple lobule"@en ;
 
          nsu:synonym "SIM"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:1008 rdf:type owl:Class ;
+MBA:1008 rdf:type owl:Class ;
 
          rdfs:label "Geniculate group, dorsal thalamus"@en ;
 
          nsu:synonym "GENd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:864 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:864 ] .
 
 
 
-ABA:1009 rdf:type owl:Class ;
+MBA:1009 rdf:type owl:Class ;
 
          rdfs:label "fiber tracts"@en ;
 
          nsu:synonym "fiber tracts"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:997 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:997 ] .
 
 
 
-ABA:101 rdf:type owl:Class ;
+MBA:101 rdf:type owl:Class ;
 
         rdfs:label "Ventral cochlear nucleus"@en ;
 
         nsu:synonym "VCO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:607 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:607 ] .
 
 
 
-ABA:1010 rdf:type owl:Class ;
+MBA:1010 rdf:type owl:Class ;
 
          rdfs:label "Visceral area, layer 4"@en ;
 
          nsu:synonym "VISC4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:1011 rdf:type owl:Class ;
+MBA:1011 rdf:type owl:Class ;
 
          rdfs:label "Dorsal auditory area"@en ;
 
          nsu:synonym "AUDd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:247 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:247 ] .
 
 
 
-ABA:1012 rdf:type owl:Class ;
+MBA:1012 rdf:type owl:Class ;
 
          rdfs:label "corticorubral tract"@en ;
 
          nsu:synonym "crt"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:1014 rdf:type owl:Class ;
+MBA:1014 rdf:type owl:Class ;
 
          rdfs:label "Geniculate group, ventral thalamus"@en ;
 
          nsu:synonym "GENv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:1015 rdf:type owl:Class ;
+MBA:1015 rdf:type owl:Class ;
 
          rdfs:label "Anterior cingulate area, dorsal part, layer 5"@en ;
 
          nsu:synonym "ACAd5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:39 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:39 ] .
 
 
 
-ABA:1016 rdf:type owl:Class ;
+MBA:1016 rdf:type owl:Class ;
 
          rdfs:label "olfactory nerve layer of main olfactory bulb"@en ;
 
          nsu:synonym "onl"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:840 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:840 ] .
 
 
 
-ABA:1017 rdf:type owl:Class ;
+MBA:1017 rdf:type owl:Class ;
 
          rdfs:label "Ansiform lobule"@en ;
 
          nsu:synonym "AN"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:1018 rdf:type owl:Class ;
+MBA:1018 rdf:type owl:Class ;
 
          rdfs:label "Ventral auditory area"@en ;
 
          nsu:synonym "AUDv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:247 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:247 ] .
 
 
 
-ABA:1019 rdf:type owl:Class ;
+MBA:1019 rdf:type owl:Class ;
 
          rdfs:label "corticospinal tract, crossed"@en ;
 
          nsu:synonym "cstc"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:102 rdf:type owl:Class ;
+MBA:102 rdf:type owl:Class ;
 
         rdfs:label "nigrostriatal tract"@en ;
 
         nsu:synonym "nst"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:1020 rdf:type owl:Class ;
+MBA:1020 rdf:type owl:Class ;
 
          rdfs:label "Posterior complex of the thalamus"@en ;
 
          nsu:synonym "PO"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:138 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:138 ] .
 
 
 
-ABA:1021 rdf:type owl:Class ;
+MBA:1021 rdf:type owl:Class ;
 
          rdfs:label "Secondary motor area, layer 6a"@en ;
 
          nsu:synonym "MOs6a"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:993 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:993 ] .
 
 
 
-ABA:1022 rdf:type owl:Class ;
+MBA:1022 rdf:type owl:Class ;
 
          rdfs:label "Globus pallidus, external segment"@en ;
 
          nsu:synonym "GPe"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:818 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:818 ] .
 
 
 
-ABA:1023 rdf:type owl:Class ;
+MBA:1023 rdf:type owl:Class ;
 
          rdfs:label "Ventral auditory area, layer 5"@en ;
 
          nsu:synonym "AUDv5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:1024 rdf:type owl:Class ;
+MBA:1024 rdf:type owl:Class ;
 
          rdfs:label "grooves"@en ;
 
          nsu:synonym "grv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:997 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:997 ] .
 
 
 
-ABA:1025 rdf:type owl:Class ;
+MBA:1025 rdf:type owl:Class ;
 
          rdfs:label "Paramedian lobule"@en ;
 
          nsu:synonym "PRM"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:1026 rdf:type owl:Class ;
+MBA:1026 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, upper limb, layer 6b"@en ;
 
          nsu:synonym "SSp-ul6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:1027 rdf:type owl:Class ;
+MBA:1027 rdf:type owl:Class ;
 
          rdfs:label "Posterior auditory area"@en ;
 
          nsu:synonym "AUDpo"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:247 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:247 ] .
 
 
 
-ABA:1028 rdf:type owl:Class ;
+MBA:1028 rdf:type owl:Class ;
 
          rdfs:label "corticospinal tract, uncrossed"@en ;
 
          nsu:synonym "cstu"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:1029 rdf:type owl:Class ;
+MBA:1029 rdf:type owl:Class ;
 
          rdfs:label "Posterior limiting nucleus of the thalamus"@en ;
 
          nsu:synonym "POL"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:138 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:138 ] .
 
 
 
-ABA:103 rdf:type owl:Class ;
+MBA:103 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part"@en ;
 
         nsu:synonym "PVHpm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:71 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:71 ] .
 
 
 
-ABA:1030 rdf:type owl:Class ;
+MBA:1030 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, lower limb, layer 1"@en ;
 
          nsu:synonym "SSp-ll1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:1031 rdf:type owl:Class ;
+MBA:1031 rdf:type owl:Class ;
 
          rdfs:label "Globus pallidus, internal segment"@en ;
 
          nsu:synonym "GPi"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:818 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:818 ] .
 
 
 
-ABA:1032 rdf:type owl:Class ;
+MBA:1032 rdf:type owl:Class ;
 
          rdfs:label "grooves of the cerebral cortex"@en ;
 
          nsu:synonym "grv of CTX"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1024 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1024 ] .
 
 
 
-ABA:1033 rdf:type owl:Class ;
+MBA:1033 rdf:type owl:Class ;
 
          rdfs:label "Copula pyramidis"@en ;
 
          nsu:synonym "COPY"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:1034 rdf:type owl:Class ;
+MBA:1034 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, dorsal part, layer 1"@en ;
 
          nsu:synonym "TTd1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:597 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:597 ] .
 
 
 
-ABA:1035 rdf:type owl:Class ;
+MBA:1035 rdf:type owl:Class ;
 
          rdfs:label "Supplemental somatosensory area, layer 4"@en ;
 
          nsu:synonym "SSs4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:1036 rdf:type owl:Class ;
+MBA:1036 rdf:type owl:Class ;
 
          rdfs:label "corticotectal tract"@en ;
 
          nsu:synonym "cte"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:1037 rdf:type owl:Class ;
+MBA:1037 rdf:type owl:Class ;
 
          rdfs:label "Postsubiculum"@en ;
 
          nsu:synonym "POST"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:822 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:822 ] .
 
 
 
-ABA:1038 rdf:type owl:Class ;
+MBA:1038 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, barrel field, layer 6a"@en ;
 
          nsu:synonym "SSp-bfd6a"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:1039 rdf:type owl:Class ;
+MBA:1039 rdf:type owl:Class ;
 
          rdfs:label "Gracile nucleus"@en ;
 
          nsu:synonym "GR"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:720 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:720 ] .
 
 
 
-ABA:104 rdf:type owl:Class ;
+MBA:104 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, dorsal part"@en ;
 
         nsu:synonym "AId"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:95 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:95 ] .
 
 
 
-ABA:1040 rdf:type owl:Class ;
+MBA:1040 rdf:type owl:Class ;
 
          rdfs:label "grooves of the cerebellar cortex"@en ;
 
          nsu:synonym "grv of CBX"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1024 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1024 ] .
 
 
 
-ABA:1041 rdf:type owl:Class ;
+MBA:1041 rdf:type owl:Class ;
 
          rdfs:label "Paraflocculus"@en ;
 
          nsu:synonym "PFL"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:1042 rdf:type owl:Class ;
+MBA:1042 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, dorsal part, layer 2"@en ;
 
          nsu:synonym "TTd2"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:597 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:597 ] .
 
 
 
-ABA:1043 rdf:type owl:Class ;
+MBA:1043 rdf:type owl:Class ;
 
          rdfs:label "crossed tectospinal pathway"@en ;
 
          nsu:synonym "tspc"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:877 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:877 ] .
 
 
 
-ABA:1044 rdf:type owl:Class ;
+MBA:1044 rdf:type owl:Class ;
 
          rdfs:label "Peripeduncular nucleus"@en ;
 
          nsu:synonym "PP"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:864 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:864 ] .
 
 
 
-ABA:1045 rdf:type owl:Class ;
+MBA:1045 rdf:type owl:Class ;
 
          rdfs:label "Ectorhinal area/Layer 6b"@en ;
 
          nsu:synonym "ECT6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:895 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:895 ] .
 
 
 
-ABA:1046 rdf:type owl:Class ;
+MBA:1046 rdf:type owl:Class ;
 
          rdfs:label "Anteromedial visual area, layer 6a"@en ;
 
          nsu:synonym "VISam6a"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:1047 rdf:type owl:Class ;
+MBA:1047 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, barrel field, layer 4"@en ;
 
          nsu:synonym "SSp-bfd4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:1048 rdf:type owl:Class ;
+MBA:1048 rdf:type owl:Class ;
 
          rdfs:label "Gigantocellular reticular nucleus"@en ;
 
          nsu:synonym "GRN"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:1049 rdf:type owl:Class ;
+MBA:1049 rdf:type owl:Class ;
 
          rdfs:label "Flocculus"@en ;
 
          nsu:synonym "FL"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1073 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1073 ] .
 
 
 
-ABA:105 rdf:type owl:Class ;
+MBA:105 rdf:type owl:Class ;
 
         rdfs:label "Superior olivary complex, medial part"@en ;
 
         nsu:synonym "SOCm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:398 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:398 ] .
 
 
 
-ABA:1050 rdf:type owl:Class ;
+MBA:1050 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, dorsal part, layer 3"@en ;
 
          nsu:synonym "TTd3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:597 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:597 ] .
 
 
 
-ABA:1051 rdf:type owl:Class ;
+MBA:1051 rdf:type owl:Class ;
 
          rdfs:label "direct tectospinal pathway"@en ;
 
          nsu:synonym "tspd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:877 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:877 ] .
 
 
 
-ABA:1052 rdf:type owl:Class ;
+MBA:1052 rdf:type owl:Class ;
 
          rdfs:label "Pedunculopontine nucleus"@en ;
 
          nsu:synonym "PPN"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:348 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:348 ] .
 
 
 
-ABA:1053 rdf:type owl:Class ;
+MBA:1053 rdf:type owl:Class ;
 
          rdfs:label "Anterior cingulate area, layer 2/3"@en ;
 
          nsu:synonym "ACA2/3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:1054 rdf:type owl:Class ;
+MBA:1054 rdf:type owl:Class ;
 
          rdfs:label "Infralimbic area, layer 6a"@en ;
 
          nsu:synonym "ILA6a"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:1055 rdf:type owl:Class ;
+MBA:1055 rdf:type owl:Class ;
 
          rdfs:label "endorhinal groove"@en ;
 
          nsu:synonym "eg"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1032 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1032 ] .
 
 
 
-ABA:1056 rdf:type owl:Class ;
+MBA:1056 rdf:type owl:Class ;
 
          rdfs:label "Crus 1"@en ;
 
          nsu:synonym "ANcr1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1017 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1017 ] .
 
 
 
-ABA:1057 rdf:type owl:Class ;
+MBA:1057 rdf:type owl:Class ;
 
          rdfs:label "Gustatory areas"@en ;
 
          nsu:synonym "GU"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:1058 rdf:type owl:Class ;
+MBA:1058 rdf:type owl:Class ;
 
          rdfs:label "Visceral area, layer 5"@en ;
 
          nsu:synonym "VISC5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:1059 rdf:type owl:Class ;
+MBA:1059 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, dorsal part, layer 4"@en ;
 
          nsu:synonym "TTd4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:597 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:597 ] .
 
 
 
-ABA:106 rdf:type owl:Class ;
+MBA:106 rdf:type owl:Class ;
 
         rdfs:label "Inferior salivatory nucleus"@en ;
 
         nsu:synonym "ISN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:1060 rdf:type owl:Class ;
+MBA:1060 rdf:type owl:Class ;
 
          rdfs:label "doral tegmental decussation"@en ;
 
          nsu:synonym "dtd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:877 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:877 ] .
 
 
 
-ABA:1061 rdf:type owl:Class ;
+MBA:1061 rdf:type owl:Class ;
 
          rdfs:label "Posterior pretectal nucleus"@en ;
 
          nsu:synonym "PPT"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:1062 rdf:type owl:Class ;
+MBA:1062 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, barrel field, layer 6b"@en ;
 
          nsu:synonym "SSp-bfd6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:1063 rdf:type owl:Class ;
+MBA:1063 rdf:type owl:Class ;
 
          rdfs:label "hippocampal fissure"@en ;
 
          nsu:synonym "hf"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1032 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1032 ] .
 
 
 
-ABA:1064 rdf:type owl:Class ;
+MBA:1064 rdf:type owl:Class ;
 
          rdfs:label "Crus 2"@en ;
 
          nsu:synonym "ANcr2"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1017 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1017 ] .
 
 
 
-ABA:1065 rdf:type owl:Class ;
+MBA:1065 rdf:type owl:Class ;
 
          rdfs:label "Hindbrain"@en ;
 
          nsu:synonym "HB"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:343 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:343 ] .
 
 
 
-ABA:1066 rdf:type owl:Class ;
+MBA:1066 rdf:type owl:Class ;
 
          rdfs:label "Anteromedial visual area, layer 2/3"@en ;
 
          nsu:synonym "VISam2/3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:1067 rdf:type owl:Class ;
+MBA:1067 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, ventral part, layer 1"@en ;
 
          nsu:synonym "TTv1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:605 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:605 ] .
 
 
 
-ABA:10671 rdf:type owl:Class ;
+MBA:10671 rdf:type owl:Class ;
 
           rdfs:label "Median eminence"@en ;
 
           nsu:synonym "ME"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1097 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1097 ] .
 
 
 
-ABA:10672 rdf:type owl:Class ;
+MBA:10672 rdf:type owl:Class ;
 
           rdfs:label "Simple lobule, granular layer"@en ;
 
           nsu:synonym "SIMgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1007 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1007 ] .
 
 
 
-ABA:10673 rdf:type owl:Class ;
+MBA:10673 rdf:type owl:Class ;
 
           rdfs:label "Simple lobule, Purkinje layer"@en ;
 
           nsu:synonym "SIMpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1007 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1007 ] .
 
 
 
-ABA:10674 rdf:type owl:Class ;
+MBA:10674 rdf:type owl:Class ;
 
           rdfs:label "Simple lobule, molecular layer"@en ;
 
           nsu:synonym "SIMmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1007 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1007 ] .
 
 
 
-ABA:10675 rdf:type owl:Class ;
+MBA:10675 rdf:type owl:Class ;
 
           rdfs:label "Crus 1, granular layer"@en ;
 
           nsu:synonym "ANcr1gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1056 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1056 ] .
 
 
 
-ABA:10676 rdf:type owl:Class ;
+MBA:10676 rdf:type owl:Class ;
 
           rdfs:label "Crus 1, Purkinje layer"@en ;
 
           nsu:synonym "ANcr1pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1056 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1056 ] .
 
 
 
-ABA:10677 rdf:type owl:Class ;
+MBA:10677 rdf:type owl:Class ;
 
           rdfs:label "Crus 1, molecular layer"@en ;
 
           nsu:synonym "ANcr1mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1056 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1056 ] .
 
 
 
-ABA:10678 rdf:type owl:Class ;
+MBA:10678 rdf:type owl:Class ;
 
           rdfs:label "Crus 2, granular layer"@en ;
 
           nsu:synonym "ANcr2gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1064 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1064 ] .
 
 
 
-ABA:10679 rdf:type owl:Class ;
+MBA:10679 rdf:type owl:Class ;
 
           rdfs:label "Crus 2, Purkinje layer"@en ;
 
           nsu:synonym "ANcr2pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1064 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1064 ] .
 
 
 
-ABA:1068 rdf:type owl:Class ;
+MBA:1068 rdf:type owl:Class ;
 
          rdfs:label "dorsal thalamus related"@en ;
 
          nsu:synonym "mfbst"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:10680 rdf:type owl:Class ;
+MBA:10680 rdf:type owl:Class ;
 
           rdfs:label "Crus 2, molecular layer"@en ;
 
           nsu:synonym "ANcr2mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1064 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1064 ] .
 
 
 
-ABA:10681 rdf:type owl:Class ;
+MBA:10681 rdf:type owl:Class ;
 
           rdfs:label "Paramedian lobule, granular layer"@en ;
 
           nsu:synonym "PRMgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1025 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1025 ] .
 
 
 
-ABA:10682 rdf:type owl:Class ;
+MBA:10682 rdf:type owl:Class ;
 
           rdfs:label "Paramedian lobule, Purkinje layer"@en ;
 
           nsu:synonym "PRMpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1025 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1025 ] .
 
 
 
-ABA:10683 rdf:type owl:Class ;
+MBA:10683 rdf:type owl:Class ;
 
           rdfs:label "Paramedian lobule, molecular layer"@en ;
 
           nsu:synonym "PRMmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1025 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1025 ] .
 
 
 
-ABA:10684 rdf:type owl:Class ;
+MBA:10684 rdf:type owl:Class ;
 
           rdfs:label "Copula pyramidis, granular layer"@en ;
 
           nsu:synonym "COPYgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1033 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1033 ] .
 
 
 
-ABA:10685 rdf:type owl:Class ;
+MBA:10685 rdf:type owl:Class ;
 
           rdfs:label "Copula pyramidis, Purkinje layer"@en ;
 
           nsu:synonym "COPYpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1033 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1033 ] .
 
 
 
-ABA:10686 rdf:type owl:Class ;
+MBA:10686 rdf:type owl:Class ;
 
           rdfs:label "Copula pyramidis, molecular layer"@en ;
 
           nsu:synonym "COPYmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1033 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1033 ] .
 
 
 
-ABA:10687 rdf:type owl:Class ;
+MBA:10687 rdf:type owl:Class ;
 
           rdfs:label "Paraflocculus, granular layer"@en ;
 
           nsu:synonym "PFLgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1041 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1041 ] .
 
 
 
-ABA:10688 rdf:type owl:Class ;
+MBA:10688 rdf:type owl:Class ;
 
           rdfs:label "Paraflocculus, Purkinje layer"@en ;
 
           nsu:synonym "PFLpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1041 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1041 ] .
 
 
 
-ABA:10689 rdf:type owl:Class ;
+MBA:10689 rdf:type owl:Class ;
 
           rdfs:label "Paraflocculus, molecular layer"@en ;
 
           nsu:synonym "PFLmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1041 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1041 ] .
 
 
 
-ABA:1069 rdf:type owl:Class ;
+MBA:1069 rdf:type owl:Class ;
 
          rdfs:label "Parapyramidal nucleus"@en ;
 
          nsu:synonym "PPY"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:10690 rdf:type owl:Class ;
+MBA:10690 rdf:type owl:Class ;
 
           rdfs:label "Flocculus, granular layer"@en ;
 
           nsu:synonym "FLgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1049 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1049 ] .
 
 
 
-ABA:10691 rdf:type owl:Class ;
+MBA:10691 rdf:type owl:Class ;
 
           rdfs:label "Flocculus, Purkinje layer"@en ;
 
           nsu:synonym "FLpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1049 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1049 ] .
 
 
 
-ABA:10692 rdf:type owl:Class ;
+MBA:10692 rdf:type owl:Class ;
 
           rdfs:label "Flocculus, molecular layer"@en ;
 
           nsu:synonym "FLmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1049 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1049 ] .
 
 
 
-ABA:10693 rdf:type owl:Class ;
+MBA:10693 rdf:type owl:Class ;
 
           rdfs:label "Parasubiculum, layer 1"@en ;
 
           nsu:synonym "PAR1"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:843 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:843 ] .
 
 
 
-ABA:10694 rdf:type owl:Class ;
+MBA:10694 rdf:type owl:Class ;
 
           rdfs:label "Parasubiculum, layer 2"@en ;
 
           nsu:synonym "PAR2"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:843 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:843 ] .
 
 
 
-ABA:10695 rdf:type owl:Class ;
+MBA:10695 rdf:type owl:Class ;
 
           rdfs:label "Parasubiculum, layer 3"@en ;
 
           nsu:synonym "PAR3"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:843 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:843 ] .
 
 
 
-ABA:10696 rdf:type owl:Class ;
+MBA:10696 rdf:type owl:Class ;
 
           rdfs:label "Postsubiculum, layer 1"@en ;
 
           nsu:synonym "POST1"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1037 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1037 ] .
 
 
 
-ABA:10697 rdf:type owl:Class ;
+MBA:10697 rdf:type owl:Class ;
 
           rdfs:label "Postsubiculum, layer 2"@en ;
 
           nsu:synonym "POST2"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1037 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1037 ] .
 
 
 
-ABA:10698 rdf:type owl:Class ;
+MBA:10698 rdf:type owl:Class ;
 
           rdfs:label "Postsubiculum, layer 3"@en ;
 
           nsu:synonym "POST3"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1037 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1037 ] .
 
 
 
-ABA:10699 rdf:type owl:Class ;
+MBA:10699 rdf:type owl:Class ;
 
           rdfs:label "Presubiculum, layer 1"@en ;
 
           nsu:synonym "PRE1"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1084 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1084 ] .
 
 
 
-ABA:107 rdf:type owl:Class ;
+MBA:107 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas, Layer 1"@en ;
 
         nsu:synonym "MO1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:1070 rdf:type owl:Class ;
+MBA:1070 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, barrel field, layer 5"@en ;
 
          nsu:synonym "SSp-bfd5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:10700 rdf:type owl:Class ;
+MBA:10700 rdf:type owl:Class ;
 
           rdfs:label "Presubiculum, layer 2"@en ;
 
           nsu:synonym "PRE2"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1084 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1084 ] .
 
 
 
-ABA:10701 rdf:type owl:Class ;
+MBA:10701 rdf:type owl:Class ;
 
           rdfs:label "Presubiculum, layer 3"@en ;
 
           nsu:synonym "PRE3"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1084 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1084 ] .
 
 
 
-ABA:10702 rdf:type owl:Class ;
+MBA:10702 rdf:type owl:Class ;
 
           rdfs:label "Dentate gyrus, subgranular zone"@en ;
 
           nsu:synonym "DG-sgz"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:10703 rdf:type owl:Class ;
+MBA:10703 rdf:type owl:Class ;
 
           rdfs:label "Dentate gyrus, molecular layer"@en ;
 
           nsu:synonym "DG-mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:10704 rdf:type owl:Class ;
+MBA:10704 rdf:type owl:Class ;
 
           rdfs:label "Dentate gyrus, polymorph layer"@en ;
 
           nsu:synonym "DG-po"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:10705 rdf:type owl:Class ;
+MBA:10705 rdf:type owl:Class ;
 
           rdfs:label "Lingula (I), granular layer"@en ;
 
           nsu:synonym "LINGgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:912 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:912 ] .
 
 
 
-ABA:10706 rdf:type owl:Class ;
+MBA:10706 rdf:type owl:Class ;
 
           rdfs:label "Lingula (I), Purkinje layer"@en ;
 
           nsu:synonym "LINGpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:912 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:912 ] .
 
 
 
-ABA:10707 rdf:type owl:Class ;
+MBA:10707 rdf:type owl:Class ;
 
           rdfs:label "Lingula (I), molecular layer"@en ;
 
           nsu:synonym "LINGmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:912 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:912 ] .
 
 
 
-ABA:10708 rdf:type owl:Class ;
+MBA:10708 rdf:type owl:Class ;
 
           rdfs:label "Lobule II, granular layer"@en ;
 
           nsu:synonym "CENT2gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:976 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:976 ] .
 
 
 
-ABA:10709 rdf:type owl:Class ;
+MBA:10709 rdf:type owl:Class ;
 
           rdfs:label "Lobule II, Purkinje layer"@en ;
 
           nsu:synonym "CENT2pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:976 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:976 ] .
 
 
 
-ABA:1071 rdf:type owl:Class ;
+MBA:1071 rdf:type owl:Class ;
 
          rdfs:label "rhinal fissure"@en ;
 
          nsu:synonym "rf"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1032 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1032 ] .
 
 
 
-ABA:10710 rdf:type owl:Class ;
+MBA:10710 rdf:type owl:Class ;
 
           rdfs:label "Lobule II, molecular layer"@en ;
 
           nsu:synonym "CENT2mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:976 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:976 ] .
 
 
 
-ABA:10711 rdf:type owl:Class ;
+MBA:10711 rdf:type owl:Class ;
 
           rdfs:label "Lobule III, granular layer"@en ;
 
           nsu:synonym "CENT3gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:984 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:984 ] .
 
 
 
-ABA:10712 rdf:type owl:Class ;
+MBA:10712 rdf:type owl:Class ;
 
           rdfs:label "Lobule III, Purkinje layer"@en ;
 
           nsu:synonym "CENT3pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:984 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:984 ] .
 
 
 
-ABA:10713 rdf:type owl:Class ;
+MBA:10713 rdf:type owl:Class ;
 
           rdfs:label "Lobule III, molecular layer"@en ;
 
           nsu:synonym "CENT3mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:984 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:984 ] .
 
 
 
-ABA:10714 rdf:type owl:Class ;
+MBA:10714 rdf:type owl:Class ;
 
           rdfs:label "Lobule IV, granular layer"@en ;
 
           nsu:synonym "CUL4gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:992 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:992 ] .
 
 
 
-ABA:10715 rdf:type owl:Class ;
+MBA:10715 rdf:type owl:Class ;
 
           rdfs:label "Lobule IV, Purkinje layer"@en ;
 
           nsu:synonym "CUL4pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:992 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:992 ] .
 
 
 
-ABA:10716 rdf:type owl:Class ;
+MBA:10716 rdf:type owl:Class ;
 
           rdfs:label "Lobule IV, molecular layer"@en ;
 
           nsu:synonym "CUL4mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:992 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:992 ] .
 
 
 
-ABA:10717 rdf:type owl:Class ;
+MBA:10717 rdf:type owl:Class ;
 
           rdfs:label "Lobule V, granular layer"@en ;
 
           nsu:synonym "CUL5gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1001 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1001 ] .
 
 
 
-ABA:10718 rdf:type owl:Class ;
+MBA:10718 rdf:type owl:Class ;
 
           rdfs:label "Lobule V, Purkinje layer"@en ;
 
           nsu:synonym "CUL5pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1001 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1001 ] .
 
 
 
-ABA:10719 rdf:type owl:Class ;
+MBA:10719 rdf:type owl:Class ;
 
           rdfs:label "Lobule V, molecular layer"@en ;
 
           nsu:synonym "CUL5mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1001 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1001 ] .
 
 
 
-ABA:1072 rdf:type owl:Class ;
+MBA:1072 rdf:type owl:Class ;
 
          rdfs:label "Medial geniculate complex, dorsal part"@en ;
 
          nsu:synonym "MGd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:475 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:475 ] .
 
 
 
-ABA:10720 rdf:type owl:Class ;
+MBA:10720 rdf:type owl:Class ;
 
           rdfs:label "Lobules IV-V, granular layer"@en ;
 
           nsu:synonym "CUL4, 5gr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1091 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1091 ] .
 
 
 
-ABA:10721 rdf:type owl:Class ;
+MBA:10721 rdf:type owl:Class ;
 
           rdfs:label "Lobules IV-V, Purkinje layer"@en ;
 
           nsu:synonym "CUL4, 5pu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1091 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1091 ] .
 
 
 
-ABA:10722 rdf:type owl:Class ;
+MBA:10722 rdf:type owl:Class ;
 
           rdfs:label "Lobules IV-V, molecular layer"@en ;
 
           nsu:synonym "CUL4, 5mo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1091 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1091 ] .
 
 
 
-ABA:10723 rdf:type owl:Class ;
+MBA:10723 rdf:type owl:Class ;
 
           rdfs:label "Declive (VI), granular layer"@en ;
 
           nsu:synonym "DECgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:936 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:936 ] .
 
 
 
-ABA:10724 rdf:type owl:Class ;
+MBA:10724 rdf:type owl:Class ;
 
           rdfs:label "Declive (VI), Purkinje layer"@en ;
 
           nsu:synonym "DECpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:936 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:936 ] .
 
 
 
-ABA:10725 rdf:type owl:Class ;
+MBA:10725 rdf:type owl:Class ;
 
           rdfs:label "Declive (VI), molecular layer"@en ;
 
           nsu:synonym "DECmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:936 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:936 ] .
 
 
 
-ABA:10726 rdf:type owl:Class ;
+MBA:10726 rdf:type owl:Class ;
 
           rdfs:label "Folium-tuber vermis (VII), granular layer"@en ;
 
           nsu:synonym "FOTUgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:944 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:944 ] .
 
 
 
-ABA:10727 rdf:type owl:Class ;
+MBA:10727 rdf:type owl:Class ;
 
           rdfs:label "Folium-tuber vermis (VII), Purkinje layer"@en ;
 
           nsu:synonym "FOTUpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:944 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:944 ] .
 
 
 
-ABA:10728 rdf:type owl:Class ;
+MBA:10728 rdf:type owl:Class ;
 
           rdfs:label "Folium-tuber vermis (VII), molecular layer"@en ;
 
           nsu:synonym "FOTUmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:944 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:944 ] .
 
 
 
-ABA:10729 rdf:type owl:Class ;
+MBA:10729 rdf:type owl:Class ;
 
           rdfs:label "Pyramus (VIII), granular layer"@en ;
 
           nsu:synonym "PYRgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:951 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:951 ] .
 
 
 
-ABA:1073 rdf:type owl:Class ;
+MBA:1073 rdf:type owl:Class ;
 
          rdfs:label "Hemispheric regions"@en ;
 
          nsu:synonym "HEM"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:528 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:528 ] .
 
 
 
-ABA:10730 rdf:type owl:Class ;
+MBA:10730 rdf:type owl:Class ;
 
           rdfs:label "Pyramus (VIII), Purkinje layer"@en ;
 
           nsu:synonym "PYRpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:951 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:951 ] .
 
 
 
-ABA:10731 rdf:type owl:Class ;
+MBA:10731 rdf:type owl:Class ;
 
           rdfs:label "Pyramus (VIII), molecular layer"@en ;
 
           nsu:synonym "PYRmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:951 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:951 ] .
 
 
 
-ABA:10732 rdf:type owl:Class ;
+MBA:10732 rdf:type owl:Class ;
 
           rdfs:label "Uvula (IX), granular layer"@en ;
 
           nsu:synonym "UVUgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:957 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:957 ] .
 
 
 
-ABA:10733 rdf:type owl:Class ;
+MBA:10733 rdf:type owl:Class ;
 
           rdfs:label "Uvula (IX), Purkinje layer"@en ;
 
           nsu:synonym "UVUpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:957 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:957 ] .
 
 
 
-ABA:10734 rdf:type owl:Class ;
+MBA:10734 rdf:type owl:Class ;
 
           rdfs:label "Uvula (IX), molecular layer"@en ;
 
           nsu:synonym "UVUmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:957 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:957 ] .
 
 
 
-ABA:10735 rdf:type owl:Class ;
+MBA:10735 rdf:type owl:Class ;
 
           rdfs:label "Nodulus (X), granular layer"@en ;
 
           nsu:synonym "NODgr"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:968 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:968 ] .
 
 
 
-ABA:10736 rdf:type owl:Class ;
+MBA:10736 rdf:type owl:Class ;
 
           rdfs:label "Nodulus (X), Purkinje layer"@en ;
 
           nsu:synonym "NODpu"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:968 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:968 ] .
 
 
 
-ABA:10737 rdf:type owl:Class ;
+MBA:10737 rdf:type owl:Class ;
 
           rdfs:label "Nodulus (X), molecular layer"@en ;
 
           nsu:synonym "NODmo"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:968 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:968 ] .
 
 
 
-ABA:1074 rdf:type owl:Class ;
+MBA:1074 rdf:type owl:Class ;
 
          rdfs:label "Anterolateral visual area, layer 1"@en ;
 
          nsu:synonym "VISal1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:1075 rdf:type owl:Class ;
+MBA:1075 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, ventral part, layer 2"@en ;
 
          nsu:synonym "TTv2"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:605 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:605 ] .
 
 
 
-ABA:1076 rdf:type owl:Class ;
+MBA:1076 rdf:type owl:Class ;
 
          rdfs:label "efferent cochleovestibular bundle"@en ;
 
          nsu:synonym "cvb"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:933 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:933 ] .
 
 
 
-ABA:1077 rdf:type owl:Class ;
+MBA:1077 rdf:type owl:Class ;
 
          rdfs:label "Perireunensis nucleus"@en ;
 
          nsu:synonym "PR"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:444 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:444 ] .
 
 
 
-ABA:1078 rdf:type owl:Class ;
+MBA:1078 rdf:type owl:Class ;
 
          rdfs:label "rhinal incisure"@en ;
 
          nsu:synonym "ri"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1032 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1032 ] .
 
 
 
-ABA:1079 rdf:type owl:Class ;
+MBA:1079 rdf:type owl:Class ;
 
          rdfs:label "Medial geniculate complex, ventral part"@en ;
 
          nsu:synonym "MGv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:475 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:475 ] .
 
 
 
-ABA:108 rdf:type owl:Class ;
+MBA:108 rdf:type owl:Class ;
 
         rdfs:label "choroid plexus"@en ;
 
         nsu:synonym "chpl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:81 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:81 ] .
 
 
 
-ABA:1080 rdf:type owl:Class ;
+MBA:1080 rdf:type owl:Class ;
 
          rdfs:label "Hippocampal region"@en ;
 
          nsu:synonym "HIP"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1089 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1089 ] .
 
 
 
-ABA:1081 rdf:type owl:Class ;
+MBA:1081 rdf:type owl:Class ;
 
          rdfs:label "Infralimbic area, layer 6b"@en ;
 
          nsu:synonym "ILA6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:1082 rdf:type owl:Class ;
+MBA:1082 rdf:type owl:Class ;
 
          rdfs:label "Taenia tecta, ventral part, layer 3"@en ;
 
          nsu:synonym "TTv3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:605 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:605 ] .
 
 
 
-ABA:1083 rdf:type owl:Class ;
+MBA:1083 rdf:type owl:Class ;
 
          rdfs:label "epithalamus related"@en ;
 
          nsu:synonym "mfbse"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:1084 rdf:type owl:Class ;
+MBA:1084 rdf:type owl:Class ;
 
          rdfs:label "Presubiculum"@en ;
 
          nsu:synonym "PRE"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:822 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:822 ] .
 
 
 
-ABA:1085 rdf:type owl:Class ;
+MBA:1085 rdf:type owl:Class ;
 
          rdfs:label "Secondary motor area, layer 6b"@en ;
 
          nsu:synonym "MOs6b"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:993 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:993 ] .
 
 
 
-ABA:1086 rdf:type owl:Class ;
+MBA:1086 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, trunk, layer 4"@en ;
 
          nsu:synonym "SSp-tr4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:1087 rdf:type owl:Class ;
+MBA:1087 rdf:type owl:Class ;
 
          rdfs:label "precentral fissure"@en ;
 
          nsu:synonym "pce"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:1088 rdf:type owl:Class ;
+MBA:1088 rdf:type owl:Class ;
 
          rdfs:label "Medial geniculate complex, medial part"@en ;
 
          nsu:synonym "MGm"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:475 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:475 ] .
 
 
 
-ABA:1089 rdf:type owl:Class ;
+MBA:1089 rdf:type owl:Class ;
 
          rdfs:label "Hippocampal formation"@en ;
 
          nsu:synonym "HPF"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:695 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:695 ] .
 
 
 
-ABA:109 rdf:type owl:Class ;
+MBA:109 rdf:type owl:Class ;
 
         rdfs:label "nigrothalamic fibers"@en ;
 
         nsu:synonym "ntt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:1090 rdf:type owl:Class ;
+MBA:1090 rdf:type owl:Class ;
 
          rdfs:label "Supplemental somatosensory area, layer 5"@en ;
 
          nsu:synonym "SSs5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:1091 rdf:type owl:Class ;
+MBA:1091 rdf:type owl:Class ;
 
          rdfs:label "Lobules IV-V"@en ;
 
          nsu:synonym "CUL4, 5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:928 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:928 ] .
 
 
 
-ABA:1092 rdf:type owl:Class ;
+MBA:1092 rdf:type owl:Class ;
 
          rdfs:label "external medullary lamina of the thalamus"@en ;
 
          nsu:synonym "em"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:896 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:896 ] .
 
 
 
-ABA:1093 rdf:type owl:Class ;
+MBA:1093 rdf:type owl:Class ;
 
          rdfs:label "Pontine reticular nucleus, caudal part"@en ;
 
          nsu:synonym "PRNc"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:1094 rdf:type owl:Class ;
+MBA:1094 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, lower limb, layer 4"@en ;
 
          nsu:synonym "SSp-ll4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:1095 rdf:type owl:Class ;
+MBA:1095 rdf:type owl:Class ;
 
          rdfs:label "preculminate fissure"@en ;
 
          nsu:synonym "pcf"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:1096 rdf:type owl:Class ;
+MBA:1096 rdf:type owl:Class ;
 
          rdfs:label "Anteromedial nucleus, dorsal part"@en ;
 
          nsu:synonym "AMd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:127 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:127 ] .
 
 
 
-ABA:1097 rdf:type owl:Class ;
+MBA:1097 rdf:type owl:Class ;
 
          rdfs:label "Hypothalamus"@en ;
 
          nsu:synonym "HY"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1129 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1129 ] .
 
 
 
-ABA:1098 rdf:type owl:Class ;
+MBA:1098 rdf:type owl:Class ;
 
          rdfs:label "Medullary reticular nucleus, dorsal part"@en ;
 
          nsu:synonym "MDRNd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:395 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:395 ] .
 
 
 
-ABA:1099 rdf:type owl:Class ;
+MBA:1099 rdf:type owl:Class ;
 
          rdfs:label "fornix system"@en ;
 
          nsu:synonym "fxs"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:11 rdf:type owl:Class ;
+MBA:11 rdf:type owl:Class ;
 
        rdfs:label "posterolateral fissure"@en ;
 
        nsu:synonym "plf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:110 rdf:type owl:Class ;
+MBA:110 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, parvicellular division, periventricular part"@en ;
 
         nsu:synonym "PVHpv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:94 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:94 ] .
 
 
 
-ABA:1100 rdf:type owl:Class ;
+MBA:1100 rdf:type owl:Class ;
 
          rdfs:label "Pretectal region"@en ;
 
          nsu:synonym "PRT"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:1101 rdf:type owl:Class ;
+MBA:1101 rdf:type owl:Class ;
 
          rdfs:label "Agranular insular area, dorsal part, layer 5"@en ;
 
          nsu:synonym "AId5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:104 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:104 ] .
 
 
 
-ABA:1102 rdf:type owl:Class ;
+MBA:1102 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, mouth, layer 6a"@en ;
 
          nsu:synonym "SSp-m6a"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:1103 rdf:type owl:Class ;
+MBA:1103 rdf:type owl:Class ;
 
          rdfs:label "primary fissure"@en ;
 
          nsu:synonym "pri"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:1104 rdf:type owl:Class ;
+MBA:1104 rdf:type owl:Class ;
 
          rdfs:label "Anteromedial nucleus, ventral part"@en ;
 
          nsu:synonym "AMv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:127 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:127 ] .
 
 
 
-ABA:1105 rdf:type owl:Class ;
+MBA:1105 rdf:type owl:Class ;
 
          rdfs:label "Intercalated amygdalar nucleus"@en ;
 
          nsu:synonym "IA"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:278 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:278 ] .
 
 
 
-ABA:1106 rdf:type owl:Class ;
+MBA:1106 rdf:type owl:Class ;
 
          rdfs:label "Visceral area, layer 2/3"@en ;
 
          nsu:synonym "VISC2/3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:1107 rdf:type owl:Class ;
+MBA:1107 rdf:type owl:Class ;
 
          rdfs:label "Medullary reticular nucleus, ventral part"@en ;
 
          nsu:synonym "MDRNv"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:395 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:395 ] .
 
 
 
-ABA:1108 rdf:type owl:Class ;
+MBA:1108 rdf:type owl:Class ;
 
          rdfs:label "genu of corpus callosum"@en ;
 
          nsu:synonym "ccg"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:1109 rdf:type owl:Class ;
+MBA:1109 rdf:type owl:Class ;
 
          rdfs:label "Parastrial nucleus"@en ;
 
          nsu:synonym "PS"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:111 rdf:type owl:Class ;
+MBA:111 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part"@en ;
 
         nsu:synonym "AIp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:95 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:95 ] .
 
 
 
-ABA:1110 rdf:type owl:Class ;
+MBA:1110 rdf:type owl:Class ;
 
          rdfs:label "Supramammillary nucleus, lateral part"@en ;
 
          nsu:synonym "SUMl"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:525 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:525 ] .
 
 
 
-ABA:1111 rdf:type owl:Class ;
+MBA:1111 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, trunk, layer 5"@en ;
 
          nsu:synonym "SSp-tr5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:1112 rdf:type owl:Class ;
+MBA:1112 rdf:type owl:Class ;
 
          rdfs:label "posterior superior fissure"@en ;
 
          nsu:synonym "psf"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:1113 rdf:type owl:Class ;
+MBA:1113 rdf:type owl:Class ;
 
          rdfs:label "Interanterodorsal nucleus of the thalamus"@en ;
 
          nsu:synonym "IAD"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:1114 rdf:type owl:Class ;
+MBA:1114 rdf:type owl:Class ;
 
          rdfs:label "Anterolateral visual area, layer 4"@en ;
 
          nsu:synonym "VISal4"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:1116 rdf:type owl:Class ;
+MBA:1116 rdf:type owl:Class ;
 
          rdfs:label "genu of the facial nerve"@en ;
 
          nsu:synonym "gVIIn"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:798 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:798 ] .
 
 
 
-ABA:1117 rdf:type owl:Class ;
+MBA:1117 rdf:type owl:Class ;
 
          rdfs:label "Pons, behavioral state related"@en ;
 
          nsu:synonym "P-sat"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:771 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:771 ] .
 
 
 
-ABA:1118 rdf:type owl:Class ;
+MBA:1118 rdf:type owl:Class ;
 
          rdfs:label "Supramammillary nucleus, medial part"@en ;
 
          nsu:synonym "SUMm"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:525 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:525 ] .
 
 
 
-ABA:1119 rdf:type owl:Class ;
+MBA:1119 rdf:type owl:Class ;
 
          rdfs:label "prepyramidal fissure"@en ;
 
          nsu:synonym "ppf"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:112 rdf:type owl:Class ;
+MBA:112 rdf:type owl:Class ;
 
         rdfs:label "Granular lamina of the cochlear nuclei"@en ;
 
         nsu:synonym "CNlam"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:607 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:607 ] .
 
 
 
-ABA:1120 rdf:type owl:Class ;
+MBA:1120 rdf:type owl:Class ;
 
          rdfs:label "Interanteromedial nucleus of the thalamus"@en ;
 
          nsu:synonym "IAM"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:1121 rdf:type owl:Class ;
+MBA:1121 rdf:type owl:Class ;
 
          rdfs:label "Entorhinal area, lateral part, layer 1"@en ;
 
          nsu:synonym "ENTl1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:1123 rdf:type owl:Class ;
+MBA:1123 rdf:type owl:Class ;
 
          rdfs:label "inferior cerebellar peduncle"@en ;
 
          nsu:synonym "icp"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:752 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:752 ] .
 
 
 
-ABA:1124 rdf:type owl:Class ;
+MBA:1124 rdf:type owl:Class ;
 
          rdfs:label "Suprachiasmatic preoptic nucleus"@en ;
 
          nsu:synonym "PSCH"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:1125 rdf:type owl:Class ;
+MBA:1125 rdf:type owl:Class ;
 
          rdfs:label "Orbital area, ventrolateral part, layer 5"@en ;
 
          nsu:synonym "ORBvl5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:746 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:746 ] .
 
 
 
-ABA:1126 rdf:type owl:Class ;
+MBA:1126 rdf:type owl:Class ;
 
          rdfs:label "Tuberomammillary nucleus, dorsal part"@en ;
 
          nsu:synonym "TMd"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:557 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:557 ] .
 
 
 
-ABA:1127 rdf:type owl:Class ;
+MBA:1127 rdf:type owl:Class ;
 
          rdfs:label "Temporal association areas, layer 2/3"@en ;
 
          nsu:synonym "TEa2/3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:1128 rdf:type owl:Class ;
+MBA:1128 rdf:type owl:Class ;
 
          rdfs:label "Primary somatosensory area, lower limb, layer 5"@en ;
 
          nsu:synonym "SSp-ll5"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:1129 rdf:type owl:Class ;
+MBA:1129 rdf:type owl:Class ;
 
          rdfs:label "Interbrain"@en ;
 
          nsu:synonym "IB"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:343 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:343 ] .
 
 
 
-ABA:113 rdf:type owl:Class ;
+MBA:113 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, lower limb, layer 2/3"@en ;
 
         nsu:synonym "SSp-ll2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:1131 rdf:type owl:Class ;
+MBA:1131 rdf:type owl:Class ;
 
          rdfs:label "intermediate nerve"@en ;
 
          nsu:synonym "iVIIn"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:798 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:798 ] .
 
 
 
-ABA:1132 rdf:type owl:Class ;
+MBA:1132 rdf:type owl:Class ;
 
          rdfs:label "Pons, sensory related"@en ;
 
          nsu:synonym "P-sen"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:771 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:771 ] .
 
 
 
-ABA:1133 rdf:type owl:Class ;
+MBA:1133 rdf:type owl:Class ;
 
          rdfs:label "Entorhinal area, medial part, ventral zone, layer 5/6"@en ;
 
          nsu:synonym "ENTmv5/6"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:934 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:934 ] .
 
 
 
-ABA:1139 rdf:type owl:Class ;
+MBA:1139 rdf:type owl:Class ;
 
          rdfs:label "Nucleus of the lateral olfactory tract, layer 3"@en ;
 
          nsu:synonym "NLOT3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:619 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:619 ] .
 
 
 
-ABA:114 rdf:type owl:Class ;
+MBA:114 rdf:type owl:Class ;
 
         rdfs:label "Superior olivary complex, lateral part"@en ;
 
         nsu:synonym "SOCl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:398 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:398 ] .
 
 
 
-ABA:1140 rdf:type owl:Class ;
+MBA:1140 rdf:type owl:Class ;
 
          rdfs:label "Postpiriform transition area, layers 1"@en ;
 
          nsu:synonym "TR1"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:566 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:566 ] .
 
 
 
-ABA:1141 rdf:type owl:Class ;
+MBA:1141 rdf:type owl:Class ;
 
          rdfs:label "Postpiriform transition area, layers 2"@en ;
 
          nsu:synonym "TR2"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:566 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:566 ] .
 
 
 
-ABA:1142 rdf:type owl:Class ;
+MBA:1142 rdf:type owl:Class ;
 
          rdfs:label "Postpiriform transition area, layers 3"@en ;
 
          nsu:synonym "TR3"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:566 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:566 ] .
 
 
 
-ABA:1143 rdf:type owl:Class ;
+MBA:1143 rdf:type owl:Class ;
 
          rdfs:label "Cerebellar cortex, granular layer"@en ;
 
          nsu:synonym "CBXgr"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:528 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:528 ] .
 
 
 
-ABA:1144 rdf:type owl:Class ;
+MBA:1144 rdf:type owl:Class ;
 
          rdfs:label "Cerebellar cortex, molecular layer"@en ;
 
          nsu:synonym "CBXmo"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:528 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:528 ] .
 
 
 
-ABA:1145 rdf:type owl:Class ;
+MBA:1145 rdf:type owl:Class ;
 
          rdfs:label "Cerebellar cortex, Purkinje layer"@en ;
 
          nsu:synonym "CBXpu"@en ;
 
-         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:528 ] .
+         rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:528 ] .
 
 
 
-ABA:115 rdf:type owl:Class ;
+MBA:115 rdf:type owl:Class ;
 
         rdfs:label "Trochlear nucleus"@en ;
 
         nsu:synonym "IV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:116 rdf:type owl:Class ;
+MBA:116 rdf:type owl:Class ;
 
         rdfs:label "choroid fissure"@en ;
 
         nsu:synonym "chfl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:81 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:81 ] .
 
 
 
-ABA:117 rdf:type owl:Class ;
+MBA:117 rdf:type owl:Class ;
 
         rdfs:label "optic chiasm"@en ;
 
         nsu:synonym "och"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:118 rdf:type owl:Class ;
+MBA:118 rdf:type owl:Class ;
 
         rdfs:label "Periventricular hypothalamic nucleus, intermediate part"@en ;
 
         nsu:synonym "PVi"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:119 rdf:type owl:Class ;
+MBA:119 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part"@en ;
 
         nsu:synonym "AIv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:95 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:95 ] .
 
 
 
-ABA:12 rdf:type owl:Class ;
+MBA:12 rdf:type owl:Class ;
 
        rdfs:label "Interfascicular nucleus raphe"@en ;
 
        nsu:synonym "IF"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:165 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:165 ] .
 
 
 
-ABA:120 rdf:type owl:Class ;
+MBA:120 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part, layer 1"@en ;
 
         nsu:synonym "AIp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:111 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:111 ] .
 
 
 
-ABA:121 rdf:type owl:Class ;
+MBA:121 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area, layer 6b"@en ;
 
         nsu:synonym "VISl6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:122 rdf:type owl:Class ;
+MBA:122 rdf:type owl:Class ;
 
         rdfs:label "Superior olivary complex, periolivary region"@en ;
 
         nsu:synonym "POR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:398 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:398 ] .
 
 
 
-ABA:123 rdf:type owl:Class ;
+MBA:123 rdf:type owl:Class ;
 
         rdfs:label "Koelliker-Fuse subnucleus"@en ;
 
         nsu:synonym "KF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:867 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:867 ] .
 
 
 
-ABA:124 rdf:type owl:Class ;
+MBA:124 rdf:type owl:Class ;
 
         rdfs:label "interventricular foramen"@en ;
 
         nsu:synonym "IVF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:125 rdf:type owl:Class ;
+MBA:125 rdf:type owl:Class ;
 
         rdfs:label "optic tract"@en ;
 
         nsu:synonym "opt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:126 rdf:type owl:Class ;
+MBA:126 rdf:type owl:Class ;
 
         rdfs:label "Periventricular hypothalamic nucleus, posterior part"@en ;
 
         nsu:synonym "PVp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:127 rdf:type owl:Class ;
+MBA:127 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial nucleus"@en ;
 
         nsu:synonym "AM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:128 rdf:type owl:Class ;
+MBA:128 rdf:type owl:Class ;
 
         rdfs:label "Midbrain reticular nucleus"@en ;
 
         nsu:synonym "MRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:129 rdf:type owl:Class ;
+MBA:129 rdf:type owl:Class ;
 
         rdfs:label "third ventricle"@en ;
 
         nsu:synonym "V3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:12993 rdf:type owl:Class ;
+MBA:12993 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 1"@en ;
 
           nsu:synonym "SS1"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:12994 rdf:type owl:Class ;
+MBA:12994 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 2/3"@en ;
 
           nsu:synonym "SS2/3"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:12995 rdf:type owl:Class ;
+MBA:12995 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 4"@en ;
 
           nsu:synonym "SS4"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:12996 rdf:type owl:Class ;
+MBA:12996 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 5"@en ;
 
           nsu:synonym "SS5"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:12997 rdf:type owl:Class ;
+MBA:12997 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 6a"@en ;
 
           nsu:synonym "SS6a"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:12998 rdf:type owl:Class ;
+MBA:12998 rdf:type owl:Class ;
 
           rdfs:label "Somatosensory areas, layer 6b"@en ;
 
           nsu:synonym "SS6b"@en ;
 
-          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+          rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:130 rdf:type owl:Class ;
+MBA:130 rdf:type owl:Class ;
 
         rdfs:label "Superior central nucleus raphe, medial part"@en ;
 
         nsu:synonym "CSm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:679 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:679 ] .
 
 
 
-ABA:131 rdf:type owl:Class ;
+MBA:131 rdf:type owl:Class ;
 
         rdfs:label "Lateral amygdalar nucleus"@en ;
 
         nsu:synonym "LA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:132 rdf:type owl:Class ;
+MBA:132 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area, layer 6b"@en ;
 
         nsu:synonym "PL6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:133 rdf:type owl:Class ;
+MBA:133 rdf:type owl:Class ;
 
         rdfs:label "Periventricular hypothalamic nucleus, preoptic part"@en ;
 
         nsu:synonym "PVpo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:134 rdf:type owl:Class ;
+MBA:134 rdf:type owl:Class ;
 
         rdfs:label "pallidotegmental fascicle"@en ;
 
         nsu:synonym "ptf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:135 rdf:type owl:Class ;
+MBA:135 rdf:type owl:Class ;
 
         rdfs:label "Nucleus ambiguus"@en ;
 
         nsu:synonym "AMB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:136 rdf:type owl:Class ;
+MBA:136 rdf:type owl:Class ;
 
         rdfs:label "Intermediate reticular nucleus"@en ;
 
         nsu:synonym "IRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:137 rdf:type owl:Class ;
+MBA:137 rdf:type owl:Class ;
 
         rdfs:label "Superior central nucleus raphe, lateral part"@en ;
 
         nsu:synonym "CSl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:679 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:679 ] .
 
 
 
-ABA:138 rdf:type owl:Class ;
+MBA:138 rdf:type owl:Class ;
 
         rdfs:label "Lateral group of the dorsal thalamus"@en ;
 
         nsu:synonym "LAT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:139 rdf:type owl:Class ;
+MBA:139 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 5"@en ;
 
         nsu:synonym "ENTl5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:14 rdf:type owl:Class ;
+MBA:14 rdf:type owl:Class ;
 
        rdfs:label "internal medullary lamina of the thalamus"@en ;
 
        nsu:synonym "im"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:896 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:896 ] .
 
 
 
-ABA:140 rdf:type owl:Class ;
+MBA:140 rdf:type owl:Class ;
 
         rdfs:label "cerebral aqueduct"@en ;
 
         nsu:synonym "AQ"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:141 rdf:type owl:Class ;
+MBA:141 rdf:type owl:Class ;
 
         rdfs:label "Periventricular region"@en ;
 
         nsu:synonym "PVR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1097 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1097 ] .
 
 
 
-ABA:142 rdf:type owl:Class ;
+MBA:142 rdf:type owl:Class ;
 
         rdfs:label "pallidothalmic pathway"@en ;
 
         nsu:synonym "pap"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:143 rdf:type owl:Class ;
+MBA:143 rdf:type owl:Class ;
 
         rdfs:label "Nucleus ambiguus, ventral division"@en ;
 
         nsu:synonym "AMBv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:135 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:135 ] .
 
 
 
-ABA:144 rdf:type owl:Class ;
+MBA:144 rdf:type owl:Class ;
 
         rdfs:label "Olfactory tubercle, layers 1-3"@en ;
 
         nsu:synonym "OT1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:145 rdf:type owl:Class ;
+MBA:145 rdf:type owl:Class ;
 
         rdfs:label "fourth ventricle"@en ;
 
         nsu:synonym "V4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:146 rdf:type owl:Class ;
+MBA:146 rdf:type owl:Class ;
 
         rdfs:label "Pontine reticular nucleus"@en ;
 
         nsu:synonym "PRNr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:147 rdf:type owl:Class ;
+MBA:147 rdf:type owl:Class ;
 
         rdfs:label "Locus ceruleus"@en ;
 
         nsu:synonym "LC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:148 rdf:type owl:Class ;
+MBA:148 rdf:type owl:Class ;
 
         rdfs:label "Gustatory areas, layer 4"@en ;
 
         nsu:synonym "GU4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:149 rdf:type owl:Class ;
+MBA:149 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular nucleus of the thalamus"@en ;
 
         nsu:synonym "PVT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:571 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:571 ] .
 
 
 
-ABA:15 rdf:type owl:Class ;
+MBA:15 rdf:type owl:Class ;
 
        rdfs:label "Parataenial nucleus"@en ;
 
        nsu:synonym "PT"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:571 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:571 ] .
 
 
 
-ABA:150 rdf:type owl:Class ;
+MBA:150 rdf:type owl:Class ;
 
         rdfs:label "periventricular bundle of the hypothalamus"@en ;
 
         nsu:synonym "pvbh"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:151 rdf:type owl:Class ;
+MBA:151 rdf:type owl:Class ;
 
         rdfs:label "Accessory olfactory bulb"@en ;
 
         nsu:synonym "AOB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:152 rdf:type owl:Class ;
+MBA:152 rdf:type owl:Class ;
 
         rdfs:label "Piriform area, layers 1-3"@en ;
 
         nsu:synonym "PIR1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:961 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:961 ] .
 
 
 
-ABA:153 rdf:type owl:Class ;
+MBA:153 rdf:type owl:Class ;
 
         rdfs:label "lateral recess"@en ;
 
         nsu:synonym "V4r"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:145 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:145 ] .
 
 
 
-ABA:154 rdf:type owl:Class ;
+MBA:154 rdf:type owl:Class ;
 
         rdfs:label "Perihypoglossal nuclei"@en ;
 
         nsu:synonym "PHY"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:155 rdf:type owl:Class ;
+MBA:155 rdf:type owl:Class ;
 
         rdfs:label "Lateral dorsal nucleus of thalamus"@en ;
 
         nsu:synonym "LD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:156 rdf:type owl:Class ;
+MBA:156 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 6a"@en ;
 
         nsu:synonym "AUDd6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:157 rdf:type owl:Class ;
+MBA:157 rdf:type owl:Class ;
 
         rdfs:label "Periventricular zone"@en ;
 
         nsu:synonym "PVZ"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1097 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1097 ] .
 
 
 
-ABA:158 rdf:type owl:Class ;
+MBA:158 rdf:type owl:Class ;
 
         rdfs:label "posterior commissure"@en ;
 
         nsu:synonym "pc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:832 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:832 ] .
 
 
 
-ABA:159 rdf:type owl:Class ;
+MBA:159 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus"@en ;
 
         nsu:synonym "AON"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:16 rdf:type owl:Class ;
+MBA:16 rdf:type owl:Class ;
 
        rdfs:label "Layer 6b, isocortex"@en ;
 
        nsu:synonym "6b"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:160 rdf:type owl:Class ;
+MBA:160 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, layer 1"@en ;
 
         nsu:synonym "AON1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:161 rdf:type owl:Class ;
+MBA:161 rdf:type owl:Class ;
 
         rdfs:label "Nucleus intercalatus"@en ;
 
         nsu:synonym "NIS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:154 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:154 ] .
 
 
 
-ABA:162 rdf:type owl:Class ;
+MBA:162 rdf:type owl:Class ;
 
         rdfs:label "Laterodorsal tegmental nucleus"@en ;
 
         nsu:synonym "LDT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:163 rdf:type owl:Class ;
+MBA:163 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part, layer 2/3"@en ;
 
         nsu:synonym "AIp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:111 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:111 ] .
 
 
 
-ABA:164 rdf:type owl:Class ;
+MBA:164 rdf:type owl:Class ;
 
         rdfs:label "central canal, spinal cord/medulla"@en ;
 
         nsu:synonym "c"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:165 rdf:type owl:Class ;
+MBA:165 rdf:type owl:Class ;
 
         rdfs:label "Midbrain raphe nuclei"@en ;
 
         nsu:synonym "RAmb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:348 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:348 ] .
 
 
 
-ABA:166 rdf:type owl:Class ;
+MBA:166 rdf:type owl:Class ;
 
         rdfs:label "premammillary commissure"@en ;
 
         nsu:synonym "pmx"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:167 rdf:type owl:Class ;
+MBA:167 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, dorsal part"@en ;
 
         nsu:synonym "AONd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:168 rdf:type owl:Class ;
+MBA:168 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, layer 2"@en ;
 
         nsu:synonym "AON2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:169 rdf:type owl:Class ;
+MBA:169 rdf:type owl:Class ;
 
         rdfs:label "Nucleus prepositus"@en ;
 
         nsu:synonym "PRP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:154 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:154 ] .
 
 
 
-ABA:17 rdf:type owl:Class ;
+MBA:17 rdf:type owl:Class ;
 
        rdfs:label "Superior colliculus, motor related, intermediate white layer"@en ;
 
        nsu:synonym "SCiw"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:294 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:294 ] .
 
 
 
-ABA:170 rdf:type owl:Class ;
+MBA:170 rdf:type owl:Class ;
 
         rdfs:label "Dorsal part of the lateral geniculate complex"@en ;
 
         nsu:synonym "LGd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1008 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1008 ] .
 
 
 
-ABA:171 rdf:type owl:Class ;
+MBA:171 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area, layer 1"@en ;
 
         nsu:synonym "PL1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:173 rdf:type owl:Class ;
+MBA:173 rdf:type owl:Class ;
 
         rdfs:label "Retrochiasmatic area"@en ;
 
         nsu:synonym "RCH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:174 rdf:type owl:Class ;
+MBA:174 rdf:type owl:Class ;
 
         rdfs:label "preoptic commissure"@en ;
 
         nsu:synonym "poc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:175 rdf:type owl:Class ;
+MBA:175 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, external part"@en ;
 
         nsu:synonym "AONe"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:177 rdf:type owl:Class ;
+MBA:177 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of Roller"@en ;
 
         nsu:synonym "NR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:154 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:154 ] .
 
 
 
-ABA:178 rdf:type owl:Class ;
+MBA:178 rdf:type owl:Class ;
 
         rdfs:label "Ventral part of the lateral geniculate complex"@en ;
 
         nsu:synonym "LGv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1014 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1014 ] .
 
 
 
-ABA:179 rdf:type owl:Class ;
+MBA:179 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, layer 6a"@en ;
 
         nsu:synonym "ACA6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:18 rdf:type owl:Class ;
+MBA:18 rdf:type owl:Class ;
 
        rdfs:label "nodular fissure"@en ;
 
        nsu:synonym "nf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:180 rdf:type owl:Class ;
+MBA:180 rdf:type owl:Class ;
 
         rdfs:label "Gustatory areas, layer 2/3"@en ;
 
         nsu:synonym "GU2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:181 rdf:type owl:Class ;
+MBA:181 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of reunions"@en ;
 
         nsu:synonym "RE"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:571 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:571 ] .
 
 
 
-ABA:182 rdf:type owl:Class ;
+MBA:182 rdf:type owl:Class ;
 
         rdfs:label "propriohypothalamic pathways"@en ;
 
         nsu:synonym "php"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:182305689 rdf:type owl:Class ;
+MBA:182305689 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned"@en ;
 
               nsu:synonym "SSp-un"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:182305693 rdf:type owl:Class ;
+MBA:182305693 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 1"@en ;
 
               nsu:synonym "SSp-un1"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:182305697 rdf:type owl:Class ;
+MBA:182305697 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 2/3"@en ;
 
               nsu:synonym "SSp-un2/3"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:182305701 rdf:type owl:Class ;
+MBA:182305701 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 4"@en ;
 
               nsu:synonym "SSp-un4"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:182305705 rdf:type owl:Class ;
+MBA:182305705 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 5"@en ;
 
               nsu:synonym "SSp-un5"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:182305709 rdf:type owl:Class ;
+MBA:182305709 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 6a"@en ;
 
               nsu:synonym "SSp-un6a"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:182305713 rdf:type owl:Class ;
+MBA:182305713 rdf:type owl:Class ;
 
               rdfs:label "Primary somatosensory area, unassigned, layer 6b"@en ;
 
               nsu:synonym "SSp-un6b"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182305689 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182305689 ] .
 
 
 
-ABA:183 rdf:type owl:Class ;
+MBA:183 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, lateral part"@en ;
 
         nsu:synonym "AONl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:184 rdf:type owl:Class ;
+MBA:184 rdf:type owl:Class ;
 
         rdfs:label "Frontal pole, cerebral cortex"@en ;
 
         nsu:synonym "FRP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:185 rdf:type owl:Class ;
+MBA:185 rdf:type owl:Class ;
 
         rdfs:label "Parapyramidal nucleus, deep part"@en ;
 
         nsu:synonym "PPYd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1069 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1069 ] .
 
 
 
-ABA:186 rdf:type owl:Class ;
+MBA:186 rdf:type owl:Class ;
 
         rdfs:label "Lateral habenula"@en ;
 
         nsu:synonym "LH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:958 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:958 ] .
 
 
 
-ABA:187 rdf:type owl:Class ;
+MBA:187 rdf:type owl:Class ;
 
         rdfs:label "Gustatory areas, layer 5"@en ;
 
         nsu:synonym "GU5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:188 rdf:type owl:Class ;
+MBA:188 rdf:type owl:Class ;
 
         rdfs:label "Accessory olfactory bulb, glomerular layer"@en ;
 
         nsu:synonym "AOBgl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:151 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:151 ] .
 
 
 
-ABA:189 rdf:type owl:Class ;
+MBA:189 rdf:type owl:Class ;
 
         rdfs:label "Rhomboid nucleus"@en ;
 
         nsu:synonym "RH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:51 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:51 ] .
 
 
 
-ABA:19 rdf:type owl:Class ;
+MBA:19 rdf:type owl:Class ;
 
        rdfs:label "Induseum griseum"@en ;
 
        nsu:synonym "IG"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1080 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1080 ] .
 
 
 
-ABA:190 rdf:type owl:Class ;
+MBA:190 rdf:type owl:Class ;
 
         rdfs:label "pyramid"@en ;
 
         nsu:synonym "py"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:191 rdf:type owl:Class ;
+MBA:191 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, medial part"@en ;
 
         nsu:synonym "AONm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:192 rdf:type owl:Class ;
+MBA:192 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, anterior part, layer 1"@en ;
 
         nsu:synonym "COAa1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:639 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:639 ] .
 
 
 
-ABA:193 rdf:type owl:Class ;
+MBA:193 rdf:type owl:Class ;
 
         rdfs:label "Parapyramidal nucleus, superficial part"@en ;
 
         nsu:synonym "PPYs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1069 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1069 ] .
 
 
 
-ABA:194 rdf:type owl:Class ;
+MBA:194 rdf:type owl:Class ;
 
         rdfs:label "Lateral hypothalamic area"@en ;
 
         nsu:synonym "LHA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:195 rdf:type owl:Class ;
+MBA:195 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area, layer 2"@en ;
 
         nsu:synonym "PL2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:196 rdf:type owl:Class ;
+MBA:196 rdf:type owl:Class ;
 
         rdfs:label "Accessory olfactory bulb, granular layer"@en ;
 
         nsu:synonym "AOBgr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:151 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:151 ] .
 
 
 
-ABA:197 rdf:type owl:Class ;
+MBA:197 rdf:type owl:Class ;
 
         rdfs:label "Rostral linear nucleus raphe"@en ;
 
         nsu:synonym "RL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:165 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:165 ] .
 
 
 
-ABA:198 rdf:type owl:Class ;
+MBA:198 rdf:type owl:Class ;
 
         rdfs:label "pyramidal decussation"@en ;
 
         nsu:synonym "pyd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:199 rdf:type owl:Class ;
+MBA:199 rdf:type owl:Class ;
 
         rdfs:label "Anterior olfactory nucleus, posteroventral part"@en ;
 
         nsu:synonym "AONpv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:159 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:159 ] .
 
 
 
-ABA:2 rdf:type owl:Class ;
+MBA:2 rdf:type owl:Class ;
 
       rdfs:label "Primary somatosensory area, mouth, layer 6b"@en ;
 
       nsu:synonym "SSp-m6b"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:20 rdf:type owl:Class ;
+MBA:20 rdf:type owl:Class ;
 
        rdfs:label "Entorhinal area, lateral part, layer 2"@en ;
 
        nsu:synonym "ENTl2"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:200 rdf:type owl:Class ;
+MBA:200 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, anterior part, layer 2"@en ;
 
         nsu:synonym "COAa2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:639 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:639 ] .
 
 
 
-ABA:201 rdf:type owl:Class ;
+MBA:201 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, barrel field, layer 2/3"@en ;
 
         nsu:synonym "SSp-bfd2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:202 rdf:type owl:Class ;
+MBA:202 rdf:type owl:Class ;
 
         rdfs:label "Medial vestibular nucleus"@en ;
 
         nsu:synonym "MV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:701 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:701 ] .
 
 
 
-ABA:203 rdf:type owl:Class ;
+MBA:203 rdf:type owl:Class ;
 
         rdfs:label "Linear nucleus of the medulla"@en ;
 
         nsu:synonym "LIN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:204 rdf:type owl:Class ;
+MBA:204 rdf:type owl:Class ;
 
         rdfs:label "Accessory olfactory bulb, mitral layer"@en ;
 
         nsu:synonym "AOBmi"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:151 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:151 ] .
 
 
 
-ABA:205 rdf:type owl:Class ;
+MBA:205 rdf:type owl:Class ;
 
         rdfs:label "retriculospinal tract, lateral part"@en ;
 
         nsu:synonym "rstl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:855 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:855 ] .
 
 
 
-ABA:206 rdf:type owl:Class ;
+MBA:206 rdf:type owl:Class ;
 
         rdfs:label "Nucleus raphe magnus"@en ;
 
         nsu:synonym "RM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:379 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:379 ] .
 
 
 
-ABA:207 rdf:type owl:Class ;
+MBA:207 rdf:type owl:Class ;
 
         rdfs:label "Area postrema"@en ;
 
         nsu:synonym "AP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:208 rdf:type owl:Class ;
+MBA:208 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, anterior part, layer 3"@en ;
 
         nsu:synonym "COAa3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:639 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:639 ] .
 
 
 
-ABA:209 rdf:type owl:Class ;
+MBA:209 rdf:type owl:Class ;
 
         rdfs:label "Lateral vestibular nucleus"@en ;
 
         nsu:synonym "LAV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:701 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:701 ] .
 
 
 
-ABA:21 rdf:type owl:Class ;
+MBA:21 rdf:type owl:Class ;
 
        rdfs:label "lateral olfactory tract, general"@en ;
 
        nsu:synonym "lotg"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:840 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:840 ] .
 
 
 
-ABA:210 rdf:type owl:Class ;
+MBA:210 rdf:type owl:Class ;
 
         rdfs:label "Lateral mammillary nucleus"@en ;
 
         nsu:synonym "LM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:331 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:331 ] .
 
 
 
-ABA:211 rdf:type owl:Class ;
+MBA:211 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, dorsal part, layer 2/3"@en ;
 
         nsu:synonym "ACAd2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:39 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:39 ] .
 
 
 
-ABA:212 rdf:type owl:Class ;
+MBA:212 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb, glomerular layer"@en ;
 
         nsu:synonym "MOBgl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:507 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:507 ] .
 
 
 
-ABA:213 rdf:type owl:Class ;
+MBA:213 rdf:type owl:Class ;
 
         rdfs:label "retriculospinal tract, medial part"@en ;
 
         nsu:synonym "rstm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:855 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:855 ] .
 
 
 
-ABA:214 rdf:type owl:Class ;
+MBA:214 rdf:type owl:Class ;
 
         rdfs:label "Red nucleus"@en ;
 
         nsu:synonym "RN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:215 rdf:type owl:Class ;
+MBA:215 rdf:type owl:Class ;
 
         rdfs:label "Anterior pretectal nucleus"@en ;
 
         nsu:synonym "APN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:216 rdf:type owl:Class ;
+MBA:216 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone, layer 1"@en ;
 
         nsu:synonym "COApl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:655 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:655 ] .
 
 
 
-ABA:217 rdf:type owl:Class ;
+MBA:217 rdf:type owl:Class ;
 
         rdfs:label "Superior vestibular nucleus"@en ;
 
         nsu:synonym "SUV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:701 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:701 ] .
 
 
 
-ABA:218 rdf:type owl:Class ;
+MBA:218 rdf:type owl:Class ;
 
         rdfs:label "Lateral posterior nucleus of the thalamus"@en ;
 
         nsu:synonym "LP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:138 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:138 ] .
 
 
 
-ABA:219 rdf:type owl:Class ;
+MBA:219 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas, Layer 2/3"@en ;
 
         nsu:synonym "MO2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:22 rdf:type owl:Class ;
+MBA:22 rdf:type owl:Class ;
 
        rdfs:label "Posterior parietal association areas"@en ;
 
        nsu:synonym "PTLp"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:220 rdf:type owl:Class ;
+MBA:220 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb, granule layer"@en ;
 
         nsu:synonym "MOBgr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:507 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:507 ] .
 
 
 
-ABA:221 rdf:type owl:Class ;
+MBA:221 rdf:type owl:Class ;
 
         rdfs:label "rubroreticular tract"@en ;
 
         nsu:synonym "rrt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:863 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:863 ] .
 
 
 
-ABA:222 rdf:type owl:Class ;
+MBA:222 rdf:type owl:Class ;
 
         rdfs:label "Nucleus raphe obscurus"@en ;
 
         nsu:synonym "RO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:379 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:379 ] .
 
 
 
-ABA:223 rdf:type owl:Class ;
+MBA:223 rdf:type owl:Class ;
 
         rdfs:label "Arcuate hypothalamic nucleus"@en ;
 
         nsu:synonym "ARH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:224 rdf:type owl:Class ;
+MBA:224 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone, layer 2"@en ;
 
         nsu:synonym "COApl2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:655 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:655 ] .
 
 
 
-ABA:225 rdf:type owl:Class ;
+MBA:225 rdf:type owl:Class ;
 
         rdfs:label "Spinal vestibular nucleus"@en ;
 
         nsu:synonym "SPIV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:701 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:701 ] .
 
 
 
-ABA:226 rdf:type owl:Class ;
+MBA:226 rdf:type owl:Class ;
 
         rdfs:label "Lateral preoptic area"@en ;
 
         nsu:synonym "LPO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:227 rdf:type owl:Class ;
+MBA:227 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, layer 6b"@en ;
 
         nsu:synonym "ACA6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:228 rdf:type owl:Class ;
+MBA:228 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb, inner plexiform layer"@en ;
 
         nsu:synonym "MOBipl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:507 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:507 ] .
 
 
 
-ABA:229 rdf:type owl:Class ;
+MBA:229 rdf:type owl:Class ;
 
         rdfs:label "sensory root of the trigeminal nerve"@en ;
 
         nsu:synonym "sV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:901 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:901 ] .
 
 
 
-ABA:23 rdf:type owl:Class ;
+MBA:23 rdf:type owl:Class ;
 
        rdfs:label "Anterior amygdalar area"@en ;
 
        nsu:synonym "AAA"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:278 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:278 ] .
 
 
 
-ABA:230 rdf:type owl:Class ;
+MBA:230 rdf:type owl:Class ;
 
         rdfs:label "Nucleus raphe pallidus"@en ;
 
         nsu:synonym "RPA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:379 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:379 ] .
 
 
 
-ABA:231 rdf:type owl:Class ;
+MBA:231 rdf:type owl:Class ;
 
         rdfs:label "Anterior tegmental nucleus"@en ;
 
         nsu:synonym "AT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:232 rdf:type owl:Class ;
+MBA:232 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone, layer 3"@en ;
 
         nsu:synonym "COApl3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:655 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:655 ] .
 
 
 
-ABA:233 rdf:type owl:Class ;
+MBA:233 rdf:type owl:Class ;
 
         rdfs:label "Anterolateral visual area, layer 5"@en ;
 
         nsu:synonym "VISal5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:234 rdf:type owl:Class ;
+MBA:234 rdf:type owl:Class ;
 
         rdfs:label "Temporal association areas, layer 4"@en ;
 
         nsu:synonym "TEa4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:235 rdf:type owl:Class ;
+MBA:235 rdf:type owl:Class ;
 
         rdfs:label "Lateral reticular nucleus"@en ;
 
         nsu:synonym "LRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:236 rdf:type owl:Class ;
+MBA:236 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb, mitral layer"@en ;
 
         nsu:synonym "MOBmi"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:507 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:507 ] .
 
 
 
-ABA:237 rdf:type owl:Class ;
+MBA:237 rdf:type owl:Class ;
 
         rdfs:label "solitary tract"@en ;
 
         nsu:synonym "ts"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:917 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:917 ] .
 
 
 
-ABA:238 rdf:type owl:Class ;
+MBA:238 rdf:type owl:Class ;
 
         rdfs:label "Nucleus raphe pontis"@en ;
 
         nsu:synonym "RPO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:239 rdf:type owl:Class ;
+MBA:239 rdf:type owl:Class ;
 
         rdfs:label "Anterior group of the dorsal thalamus"@en ;
 
         nsu:synonym "ATN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:240 rdf:type owl:Class ;
+MBA:240 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone, layer 1"@en ;
 
         nsu:synonym "COApm1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:663 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:663 ] .
 
 
 
-ABA:241 rdf:type owl:Class ;
+MBA:241 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 2/3"@en ;
 
         nsu:synonym "PTLp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:242 rdf:type owl:Class ;
+MBA:242 rdf:type owl:Class ;
 
         rdfs:label "Lateral septal nucleus"@en ;
 
         nsu:synonym "LS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:275 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:275 ] .
 
 
 
-ABA:243 rdf:type owl:Class ;
+MBA:243 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 6b"@en ;
 
         nsu:synonym "AUDd6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:244 rdf:type owl:Class ;
+MBA:244 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb, outer plexiform layer"@en ;
 
         nsu:synonym "MOBopl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:507 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:507 ] .
 
 
 
-ABA:245 rdf:type owl:Class ;
+MBA:245 rdf:type owl:Class ;
 
         rdfs:label "spinocervical tract"@en ;
 
         nsu:synonym "scrt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:246 rdf:type owl:Class ;
+MBA:246 rdf:type owl:Class ;
 
         rdfs:label "Midbrain reticular nucleus, retrorubral area"@en ;
 
         nsu:synonym "RR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:247 rdf:type owl:Class ;
+MBA:247 rdf:type owl:Class ;
 
         rdfs:label "Auditory areas"@en ;
 
         nsu:synonym "AUD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:248 rdf:type owl:Class ;
+MBA:248 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone, layer 2"@en ;
 
         nsu:synonym "COApm2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:663 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:663 ] .
 
 
 
-ABA:249 rdf:type owl:Class ;
+MBA:249 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 6a"@en ;
 
         nsu:synonym "AUDpo6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:25 rdf:type owl:Class ;
+MBA:25 rdf:type owl:Class ;
 
        rdfs:label "simple fissure"@en ;
 
        nsu:synonym "sif"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:250 rdf:type owl:Class ;
+MBA:250 rdf:type owl:Class ;
 
         rdfs:label "Lateral septal nucleus, caudal (caudodorsal) part"@en ;
 
         nsu:synonym "LSc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:242 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:242 ] .
 
 
 
-ABA:251 rdf:type owl:Class ;
+MBA:251 rdf:type owl:Class ;
 
         rdfs:label "Primary auditory area, layer 2/3"@en ;
 
         nsu:synonym "AUDp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:252 rdf:type owl:Class ;
+MBA:252 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 5"@en ;
 
         nsu:synonym "AUDd5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:253 rdf:type owl:Class ;
+MBA:253 rdf:type owl:Class ;
 
         rdfs:label "spinohypothalamic pathway"@en ;
 
         nsu:synonym "shp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:254 rdf:type owl:Class ;
+MBA:254 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area"@en ;
 
         nsu:synonym "RSP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:255 rdf:type owl:Class ;
+MBA:255 rdf:type owl:Class ;
 
         rdfs:label "Anteroventral nucleus of thalamus"@en ;
 
         nsu:synonym "AV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:256 rdf:type owl:Class ;
+MBA:256 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone, layer 3"@en ;
 
         nsu:synonym "COApm3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:663 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:663 ] .
 
 
 
-ABA:257 rdf:type owl:Class ;
+MBA:257 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area, layer 6a"@en ;
 
         nsu:synonym "VISpm6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:258 rdf:type owl:Class ;
+MBA:258 rdf:type owl:Class ;
 
         rdfs:label "Lateral septal nucleus, rostral (rostroventral) part"@en ;
 
         nsu:synonym "LSr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:242 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:242 ] .
 
 
 
-ABA:259 rdf:type owl:Class ;
+MBA:259 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, ventral zone, layer 1"@en ;
 
         nsu:synonym "ENTmv1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:934 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:934 ] .
 
 
 
-ABA:26 rdf:type owl:Class ;
+MBA:26 rdf:type owl:Class ;
 
        rdfs:label "Superior colliculus, motor related, deep gray layer"@en ;
 
        nsu:synonym "SCdg"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:294 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:294 ] .
 
 
 
-ABA:260 rdf:type owl:Class ;
+MBA:260 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the lateral olfactory tract, molecular layer"@en ;
 
         nsu:synonym "NLOT1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:619 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:619 ] .
 
 
 
-ABA:261 rdf:type owl:Class ;
+MBA:261 rdf:type owl:Class ;
 
         rdfs:label "spino-olivary pathway"@en ;
 
         nsu:synonym "sop"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:262 rdf:type owl:Class ;
+MBA:262 rdf:type owl:Class ;
 
         rdfs:label "Reticular nucleus of the thalamus"@en ;
 
         nsu:synonym "RT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:263 rdf:type owl:Class ;
+MBA:263 rdf:type owl:Class ;
 
         rdfs:label "Anteroventral preoptic nucleus"@en ;
 
         nsu:synonym "AVP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:264 rdf:type owl:Class ;
+MBA:264 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, layer 1"@en ;
 
         nsu:synonym "ORB1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:266 rdf:type owl:Class ;
+MBA:266 rdf:type owl:Class ;
 
         rdfs:label "Lateral septal nucleus, ventral part"@en ;
 
         nsu:synonym "LSv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:242 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:242 ] .
 
 
 
-ABA:267 rdf:type owl:Class ;
+MBA:267 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area, layer 6a"@en ;
 
         nsu:synonym "DP6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:814 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:814 ] .
 
 
 
-ABA:268 rdf:type owl:Class ;
+MBA:268 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the lateral olfactory tract, pyramidal layer"@en ;
 
         nsu:synonym "NLOT2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:619 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:619 ] .
 
 
 
-ABA:269 rdf:type owl:Class ;
+MBA:269 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 2/3"@en ;
 
         nsu:synonym "VISpl2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:27 rdf:type owl:Class ;
+MBA:27 rdf:type owl:Class ;
 
        rdfs:label "Intergeniculate leaflet of the lateral geniculate complex"@en ;
 
        nsu:synonym "IGL"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1014 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1014 ] .
 
 
 
-ABA:270 rdf:type owl:Class ;
+MBA:270 rdf:type owl:Class ;
 
         rdfs:label "spinoreticular pathway"@en ;
 
         nsu:synonym "srp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:271 rdf:type owl:Class ;
+MBA:271 rdf:type owl:Class ;
 
         rdfs:label "Nucleus sagulum"@en ;
 
         nsu:synonym "SAG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:272 rdf:type owl:Class ;
+MBA:272 rdf:type owl:Class ;
 
         rdfs:label "Anteroventral periventricular nucleus"@en ;
 
         nsu:synonym "AVPV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:274 rdf:type owl:Class ;
+MBA:274 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 6a"@en ;
 
         nsu:synonym "RSPd6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:275 rdf:type owl:Class ;
+MBA:275 rdf:type owl:Class ;
 
         rdfs:label "Lateral septal complex"@en ;
 
         nsu:synonym "LSX"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:477 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:477 ] .
 
 
 
-ABA:276 rdf:type owl:Class ;
+MBA:276 rdf:type owl:Class ;
 
         rdfs:label "Piriform area, molecular layer"@en ;
 
         nsu:synonym "PIR1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:961 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:961 ] .
 
 
 
-ABA:277 rdf:type owl:Class ;
+MBA:277 rdf:type owl:Class ;
 
         rdfs:label "spinotectal pathway"@en ;
 
         nsu:synonym "stp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:278 rdf:type owl:Class ;
+MBA:278 rdf:type owl:Class ;
 
         rdfs:label "Striatum-like amygdalar nuclei"@en ;
 
         nsu:synonym "sAMY"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:477 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:477 ] .
 
 
 
-ABA:279 rdf:type owl:Class ;
+MBA:279 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part, layer 6b"@en ;
 
         nsu:synonym "RSPagl6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:894 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:894 ] .
 
 
 
-ABA:28 rdf:type owl:Class ;
+MBA:28 rdf:type owl:Class ;
 
        rdfs:label "Entorhinal area, lateral part, layer 6a"@en ;
 
        nsu:synonym "ENTl6a"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:280 rdf:type owl:Class ;
+MBA:280 rdf:type owl:Class ;
 
         rdfs:label "Barrington's nucleus"@en ;
 
         nsu:synonym "B"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:281 rdf:type owl:Class ;
+MBA:281 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial visual area, layer 1"@en ;
 
         nsu:synonym "VISam1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:283 rdf:type owl:Class ;
+MBA:283 rdf:type owl:Class ;
 
         rdfs:label "Lateral tegmental nucleus"@en ;
 
         nsu:synonym "LTN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:284 rdf:type owl:Class ;
+MBA:284 rdf:type owl:Class ;
 
         rdfs:label "Piriform area, pyramidal layer"@en ;
 
         nsu:synonym "PIR2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:961 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:961 ] .
 
 
 
-ABA:285 rdf:type owl:Class ;
+MBA:285 rdf:type owl:Class ;
 
         rdfs:label "spinotelenchephalic pathway"@en ;
 
         nsu:synonym "step"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:286 rdf:type owl:Class ;
+MBA:286 rdf:type owl:Class ;
 
         rdfs:label "Suprachiasmatic nucleus"@en ;
 
         nsu:synonym "SCH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:287 rdf:type owl:Class ;
+MBA:287 rdf:type owl:Class ;
 
         rdfs:label "Bed nucleus of the anterior commissure"@en ;
 
         nsu:synonym "BAC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:809 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:809 ] .
 
 
 
-ABA:288 rdf:type owl:Class ;
+MBA:288 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventrolateral part, layer 2/3"@en ;
 
         nsu:synonym "ORBvl2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:746 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:746 ] .
 
 
 
-ABA:289 rdf:type owl:Class ;
+MBA:289 rdf:type owl:Class ;
 
         rdfs:label "Temporal association areas, layer 5"@en ;
 
         nsu:synonym "TEa5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:29 rdf:type owl:Class ;
+MBA:29 rdf:type owl:Class ;
 
        rdfs:label "lateral spinothalamic tract"@en ;
 
        nsu:synonym "sttl"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:290 rdf:type owl:Class ;
+MBA:290 rdf:type owl:Class ;
 
         rdfs:label "Hypothalamic lateral zone"@en ;
 
         nsu:synonym "LZ"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1097 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1097 ] .
 
 
 
-ABA:291 rdf:type owl:Class ;
+MBA:291 rdf:type owl:Class ;
 
         rdfs:label "Piriform area, polymorph layer"@en ;
 
         nsu:synonym "PIR3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:961 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:961 ] .
 
 
 
-ABA:292 rdf:type owl:Class ;
+MBA:292 rdf:type owl:Class ;
 
         rdfs:label "Bed nucleus of the accessory olfactory tract"@en ;
 
         nsu:synonym "BA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:278 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:278 ] .
 
 
 
-ABA:293 rdf:type owl:Class ;
+MBA:293 rdf:type owl:Class ;
 
         rdfs:label "spinovestibular pathway"@en ;
 
         nsu:synonym "svp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:294 rdf:type owl:Class ;
+MBA:294 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, motor related"@en ;
 
         nsu:synonym "SCm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:295 rdf:type owl:Class ;
+MBA:295 rdf:type owl:Class ;
 
         rdfs:label "Basolateral amygdalar nucleus"@en ;
 
         nsu:synonym "BLA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:296 rdf:type owl:Class ;
+MBA:296 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, ventral part, layer 2/3"@en ;
 
         nsu:synonym "ACAv2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:48 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:48 ] .
 
 
 
-ABA:297 rdf:type owl:Class ;
+MBA:297 rdf:type owl:Class ;
 
         rdfs:label "Taenia tecta, dorsal part, layers 1-4"@en ;
 
         nsu:synonym "TTd1-4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:597 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:597 ] .
 
 
 
-ABA:298 rdf:type owl:Class ;
+MBA:298 rdf:type owl:Class ;
 
         rdfs:label "Magnocellular nucleus"@en ;
 
         nsu:synonym "MA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:835 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:835 ] .
 
 
 
-ABA:299 rdf:type owl:Class ;
+MBA:299 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas, Layer 5"@en ;
 
         nsu:synonym "MO5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:3 rdf:type owl:Class ;
+MBA:3 rdf:type owl:Class ;
 
       rdfs:label "secondary fissure"@en ;
 
       nsu:synonym "sec"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:30 rdf:type owl:Class ;
+MBA:30 rdf:type owl:Class ;
 
        rdfs:label "Periventricular hypothalamic nucleus, anterior part"@en ;
 
        nsu:synonym "PVa"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:300 rdf:type owl:Class ;
+MBA:300 rdf:type owl:Class ;
 
         rdfs:label "Ventral part of the lateral geniculate complex, lateral zone"@en ;
 
         nsu:synonym "LGvl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:178 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:178 ] .
 
 
 
-ABA:301 rdf:type owl:Class ;
+MBA:301 rdf:type owl:Class ;
 
         rdfs:label "stria terminalis"@en ;
 
         nsu:synonym "st"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:302 rdf:type owl:Class ;
+MBA:302 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, sensory related"@en ;
 
         nsu:synonym "SCs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:303 rdf:type owl:Class ;
+MBA:303 rdf:type owl:Class ;
 
         rdfs:label "Basolateral amygdalar nucleus, anterior part"@en ;
 
         nsu:synonym "BLAa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:295 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:295 ] .
 
 
 
-ABA:304 rdf:type owl:Class ;
+MBA:304 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area, layer 2/3"@en ;
 
         nsu:synonym "PL2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:304325711 rdf:type owl:Class ;
+MBA:304325711 rdf:type owl:Class ;
 
               rdfs:label "retina"@en ;
 
               nsu:synonym "retina"@en ;
 
-              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:997 ] .
+              rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:997 ] .
 
 
 
-ABA:305 rdf:type owl:Class ;
+MBA:305 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area, layer 6b"@en ;
 
         nsu:synonym "VISp6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:306 rdf:type owl:Class ;
+MBA:306 rdf:type owl:Class ;
 
         rdfs:label "Taenia tecta, ventral part, layers 1-3"@en ;
 
         nsu:synonym "TTv1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:605 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:605 ] .
 
 
 
-ABA:307 rdf:type owl:Class ;
+MBA:307 rdf:type owl:Class ;
 
         rdfs:label "Magnocellular reticular nucleus"@en ;
 
         nsu:synonym "MARN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:308 rdf:type owl:Class ;
+MBA:308 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 6a"@en ;
 
         nsu:synonym "PTLp6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:309 rdf:type owl:Class ;
+MBA:309 rdf:type owl:Class ;
 
         rdfs:label "striatonigral pathway"@en ;
 
         nsu:synonym "snp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:31 rdf:type owl:Class ;
+MBA:31 rdf:type owl:Class ;
 
        rdfs:label "Anterior cingulate area"@en ;
 
        nsu:synonym "ACA"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:310 rdf:type owl:Class ;
+MBA:310 rdf:type owl:Class ;
 
         rdfs:label "Septofimbrial nucleus"@en ;
 
         nsu:synonym "SF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:275 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:275 ] .
 
 
 
-ABA:311 rdf:type owl:Class ;
+MBA:311 rdf:type owl:Class ;
 
         rdfs:label "Basolateral amygdalar nucleus, posterior part"@en ;
 
         nsu:synonym "BLAp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:295 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:295 ] .
 
 
 
-ABA:312 rdf:type owl:Class ;
+MBA:312 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 4/5"@en ;
 
         nsu:synonym "ENTl4/5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:313 rdf:type owl:Class ;
+MBA:313 rdf:type owl:Class ;
 
         rdfs:label "Midbrain"@en ;
 
         nsu:synonym "MB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:343 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:343 ] .
 
 
 
-ABA:314 rdf:type owl:Class ;
+MBA:314 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part, layer 6a"@en ;
 
         nsu:synonym "AIp6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:111 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:111 ] .
 
 
 
-ABA:315 rdf:type owl:Class ;
+MBA:315 rdf:type owl:Class ;
 
         rdfs:label "Isocortex"@en ;
 
         nsu:synonym "Isocortex"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:695 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:695 ] .
 
 
 
-ABA:316 rdf:type owl:Class ;
+MBA:316 rdf:type owl:Class ;
 
         rdfs:label "Ventral part of the lateral geniculate complex, medial zone"@en ;
 
         nsu:synonym "LGvm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:178 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:178 ] .
 
 
 
-ABA:317 rdf:type owl:Class ;
+MBA:317 rdf:type owl:Class ;
 
         rdfs:label "subthalamic fascicle"@en ;
 
         nsu:synonym "stf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:760 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:760 ] .
 
 
 
-ABA:318 rdf:type owl:Class ;
+MBA:318 rdf:type owl:Class ;
 
         rdfs:label "Supragenual nucleus"@en ;
 
         nsu:synonym "SG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:319 rdf:type owl:Class ;
+MBA:319 rdf:type owl:Class ;
 
         rdfs:label "Basomedial amygdalar nucleus"@en ;
 
         nsu:synonym "BMA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:320 rdf:type owl:Class ;
+MBA:320 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area, Layer 1"@en ;
 
         nsu:synonym "MOp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:985 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:985 ] .
 
 
 
-ABA:321 rdf:type owl:Class ;
+MBA:321 rdf:type owl:Class ;
 
         rdfs:label "Subgeniculate nucleus"@en ;
 
         nsu:synonym "SubG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1014 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1014 ] .
 
 
 
-ABA:322 rdf:type owl:Class ;
+MBA:322 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area"@en ;
 
         nsu:synonym "SSp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:323 rdf:type owl:Class ;
+MBA:323 rdf:type owl:Class ;
 
         rdfs:label "Midbrain, motor related"@en ;
 
         nsu:synonym "MBmot"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:313 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:313 ] .
 
 
 
-ABA:324 rdf:type owl:Class ;
+MBA:324 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, ventral zone, layer 2"@en ;
 
         nsu:synonym "ENTmv2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:934 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:934 ] .
 
 
 
-ABA:325 rdf:type owl:Class ;
+MBA:325 rdf:type owl:Class ;
 
         rdfs:label "Suprageniculate nucleus"@en ;
 
         nsu:synonym "SGN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:138 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:138 ] .
 
 
 
-ABA:326 rdf:type owl:Class ;
+MBA:326 rdf:type owl:Class ;
 
         rdfs:label "superior cerebelar peduncles"@en ;
 
         nsu:synonym "scp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:752 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:752 ] .
 
 
 
-ABA:327 rdf:type owl:Class ;
+MBA:327 rdf:type owl:Class ;
 
         rdfs:label "Basomedial amygdalar nucleus, anterior part"@en ;
 
         nsu:synonym "BMAa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:319 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:319 ] .
 
 
 
-ABA:328 rdf:type owl:Class ;
+MBA:328 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, dorsal part, layer 2/3"@en ;
 
         nsu:synonym "AId2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:104 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:104 ] .
 
 
 
-ABA:329 rdf:type owl:Class ;
+MBA:329 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, barrel field"@en ;
 
         nsu:synonym "SSp-bfd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:33 rdf:type owl:Class ;
+MBA:33 rdf:type owl:Class ;
 
        rdfs:label "Primary visual area, layer 6a"@en ;
 
        nsu:synonym "VISp6a"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:330 rdf:type owl:Class ;
+MBA:330 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 6b"@en ;
 
         nsu:synonym "RSPd6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:331 rdf:type owl:Class ;
+MBA:331 rdf:type owl:Class ;
 
         rdfs:label "Mammillary body"@en ;
 
         nsu:synonym "MBO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:332 rdf:type owl:Class ;
+MBA:332 rdf:type owl:Class ;
 
         rdfs:label "Accessory supraoptic group"@en ;
 
         nsu:synonym "ASO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:333 rdf:type owl:Class ;
+MBA:333 rdf:type owl:Class ;
 
         rdfs:label "Septohippocampal nucleus"@en ;
 
         nsu:synonym "SH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:275 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:275 ] .
 
 
 
-ABA:334 rdf:type owl:Class ;
+MBA:334 rdf:type owl:Class ;
 
         rdfs:label "Basomedial amygdalar nucleus, posterior part"@en ;
 
         nsu:synonym "BMAp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:319 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:319 ] .
 
 
 
-ABA:335 rdf:type owl:Class ;
+MBA:335 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area, layer 6a"@en ;
 
         nsu:synonym "PERI6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:922 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:922 ] .
 
 
 
-ABA:336 rdf:type owl:Class ;
+MBA:336 rdf:type owl:Class ;
 
         rdfs:label "superior colliculus commissure"@en ;
 
         nsu:synonym "csc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:337 rdf:type owl:Class ;
+MBA:337 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, lower limb"@en ;
 
         nsu:synonym "SSp-ll"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:338 rdf:type owl:Class ;
+MBA:338 rdf:type owl:Class ;
 
         rdfs:label "Subfornical organ"@en ;
 
         nsu:synonym "SFO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:339 rdf:type owl:Class ;
+MBA:339 rdf:type owl:Class ;
 
         rdfs:label "Midbrain, sensory related"@en ;
 
         nsu:synonym "MBsen"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:313 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:313 ] .
 
 
 
-ABA:34 rdf:type owl:Class ;
+MBA:34 rdf:type owl:Class ;
 
        rdfs:label "intercrural fissure"@en ;
 
        nsu:synonym "icf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:340 rdf:type owl:Class ;
+MBA:340 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 6b"@en ;
 
         nsu:synonym "PTLp6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:341 rdf:type owl:Class ;
+MBA:341 rdf:type owl:Class ;
 
         rdfs:label "supramammillary decussation"@en ;
 
         nsu:synonym "smd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:342 rdf:type owl:Class ;
+MBA:342 rdf:type owl:Class ;
 
         rdfs:label "Substantia innominata"@en ;
 
         nsu:synonym "SI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:835 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:835 ] .
 
 
 
-ABA:343 rdf:type owl:Class ;
+MBA:343 rdf:type owl:Class ;
 
         rdfs:label "Brain stem"@en ;
 
         nsu:synonym "BS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:8 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:8 ] .
 
 
 
-ABA:344 rdf:type owl:Class ;
+MBA:344 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part, layer 5"@en ;
 
         nsu:synonym "AIp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:111 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:111 ] .
 
 
 
-ABA:345 rdf:type owl:Class ;
+MBA:345 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, mouth"@en ;
 
         nsu:synonym "SSp-m"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:346 rdf:type owl:Class ;
+MBA:346 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 2/3"@en ;
 
         nsu:synonym "SSp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:347 rdf:type owl:Class ;
+MBA:347 rdf:type owl:Class ;
 
         rdfs:label "Subparaventricular zone"@en ;
 
         nsu:synonym "SBPV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:348 rdf:type owl:Class ;
+MBA:348 rdf:type owl:Class ;
 
         rdfs:label "Midbrain, behavioral state related"@en ;
 
         nsu:synonym "MBsta"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:313 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:313 ] .
 
 
 
-ABA:349 rdf:type owl:Class ;
+MBA:349 rdf:type owl:Class ;
 
         rdfs:label "supraoptic commissures"@en ;
 
         nsu:synonym "sup"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:35 rdf:type owl:Class ;
+MBA:35 rdf:type owl:Class ;
 
        rdfs:label "Oculomotor nucleus"@en ;
 
        nsu:synonym "III"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:350 rdf:type owl:Class ;
+MBA:350 rdf:type owl:Class ;
 
         rdfs:label "Subceruleus nucleus"@en ;
 
         nsu:synonym "SLC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:351 rdf:type owl:Class ;
+MBA:351 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis"@en ;
 
         nsu:synonym "BST"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:809 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:809 ] .
 
 
 
-ABA:352 rdf:type owl:Class ;
+MBA:352 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, layer 5"@en ;
 
         nsu:synonym "ORB5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:353 rdf:type owl:Class ;
+MBA:353 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose"@en ;
 
         nsu:synonym "SSp-n"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:354 rdf:type owl:Class ;
+MBA:354 rdf:type owl:Class ;
 
         rdfs:label "Medulla"@en ;
 
         nsu:synonym "MY"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1065 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1065 ] .
 
 
 
-ABA:355 rdf:type owl:Class ;
+MBA:355 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, posterior part, layer 6b"@en ;
 
         nsu:synonym "AIp6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:111 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:111 ] .
 
 
 
-ABA:356 rdf:type owl:Class ;
+MBA:356 rdf:type owl:Class ;
 
         rdfs:label "Preparasubthalamic nucleus"@en ;
 
         nsu:synonym "PST"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:357 rdf:type owl:Class ;
+MBA:357 rdf:type owl:Class ;
 
         rdfs:label "tectothalamic pathway"@en ;
 
         nsu:synonym "ttp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:358 rdf:type owl:Class ;
+MBA:358 rdf:type owl:Class ;
 
         rdfs:label "Sublaterodorsal nucleus"@en ;
 
         nsu:synonym "SLD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:359 rdf:type owl:Class ;
+MBA:359 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division"@en ;
 
         nsu:synonym "BSTa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:351 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:351 ] .
 
 
 
-ABA:36 rdf:type owl:Class ;
+MBA:36 rdf:type owl:Class ;
 
        rdfs:label "Gustatory areas, layer 1"@en ;
 
        nsu:synonym "GU1"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:360 rdf:type owl:Class ;
+MBA:360 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area, layer 2/3"@en ;
 
         nsu:synonym "DP2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:814 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:814 ] .
 
 
 
-ABA:361 rdf:type owl:Class ;
+MBA:361 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, trunk"@en ;
 
         nsu:synonym "SSp-tr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:362 rdf:type owl:Class ;
+MBA:362 rdf:type owl:Class ;
 
         rdfs:label "Mediodorsal nucleus of thalamus"@en ;
 
         nsu:synonym "MD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:444 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:444 ] .
 
 
 
-ABA:363 rdf:type owl:Class ;
+MBA:363 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area, layer 5"@en ;
 
         nsu:synonym "PL5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:364 rdf:type owl:Class ;
+MBA:364 rdf:type owl:Class ;
 
         rdfs:label "Parasubthalamic nucleus"@en ;
 
         nsu:synonym "PSTN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:365 rdf:type owl:Class ;
+MBA:365 rdf:type owl:Class ;
 
         rdfs:label "thalamic peduncles"@en ;
 
         nsu:synonym "tp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:896 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:896 ] .
 
 
 
-ABA:366 rdf:type owl:Class ;
+MBA:366 rdf:type owl:Class ;
 
         rdfs:label "Submedial nucleus of the thalamus"@en ;
 
         nsu:synonym "SMT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:444 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:444 ] .
 
 
 
-ABA:367 rdf:type owl:Class ;
+MBA:367 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division"@en ;
 
         nsu:synonym "BSTp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:351 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:351 ] .
 
 
 
-ABA:368 rdf:type owl:Class ;
+MBA:368 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area, layer 6b"@en ;
 
         nsu:synonym "PERI6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:922 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:922 ] .
 
 
 
-ABA:369 rdf:type owl:Class ;
+MBA:369 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb"@en ;
 
         nsu:synonym "SSp-ul"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:37 rdf:type owl:Class ;
+MBA:37 rdf:type owl:Class ;
 
        rdfs:label "longitudinal association bundle"@en ;
 
        nsu:synonym "lab"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:370 rdf:type owl:Class ;
+MBA:370 rdf:type owl:Class ;
 
         rdfs:label "Medulla, motor related"@en ;
 
         nsu:synonym "MY-mot"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:354 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:354 ] .
 
 
 
-ABA:371 rdf:type owl:Class ;
+MBA:371 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, ventral zone, layer 3"@en ;
 
         nsu:synonym "ENTmv3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:934 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:934 ] .
 
 
 
-ABA:372 rdf:type owl:Class ;
+MBA:372 rdf:type owl:Class ;
 
         rdfs:label "Infracerebellar nucleus"@en ;
 
         nsu:synonym "ICB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:373 rdf:type owl:Class ;
+MBA:373 rdf:type owl:Class ;
 
         rdfs:label "trigeminocerebellar tract"@en ;
 
         nsu:synonym "tct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:752 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:752 ] .
 
 
 
-ABA:374 rdf:type owl:Class ;
+MBA:374 rdf:type owl:Class ;
 
         rdfs:label "Substantia nigra, compact part"@en ;
 
         nsu:synonym "SNc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:348 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:348 ] .
 
 
 
-ABA:375 rdf:type owl:Class ;
+MBA:375 rdf:type owl:Class ;
 
         rdfs:label "Ammon's horn"@en ;
 
         nsu:synonym "CA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1080 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1080 ] .
 
 
 
-ABA:376 rdf:type owl:Class ;
+MBA:376 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone, layers 1-3"@en ;
 
         nsu:synonym "COApl1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:655 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:655 ] .
 
 
 
-ABA:377 rdf:type owl:Class ;
+MBA:377 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 6a"@en ;
 
         nsu:synonym "VISpl6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:378 rdf:type owl:Class ;
+MBA:378 rdf:type owl:Class ;
 
         rdfs:label "Supplemental somatosensory area"@en ;
 
         nsu:synonym "SSs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:453 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:453 ] .
 
 
 
-ABA:379 rdf:type owl:Class ;
+MBA:379 rdf:type owl:Class ;
 
         rdfs:label "Medulla, behavioral state related"@en ;
 
         nsu:synonym "MY-sat"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:354 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:354 ] .
 
 
 
-ABA:38 rdf:type owl:Class ;
+MBA:38 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus"@en ;
 
        nsu:synonym "PVH"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:380 rdf:type owl:Class ;
+MBA:380 rdf:type owl:Class ;
 
         rdfs:label "cuneate fascicle"@en ;
 
         nsu:synonym "cuf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:514 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:514 ] .
 
 
 
-ABA:381 rdf:type owl:Class ;
+MBA:381 rdf:type owl:Class ;
 
         rdfs:label "Substantia nigra, reticular part"@en ;
 
         nsu:synonym "SNr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:382 rdf:type owl:Class ;
+MBA:382 rdf:type owl:Class ;
 
         rdfs:label "Field CA1"@en ;
 
         nsu:synonym "CA1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:375 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:375 ] .
 
 
 
-ABA:383 rdf:type owl:Class ;
+MBA:383 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone, layers 1-3"@en ;
 
         nsu:synonym "COApm1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:663 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:663 ] .
 
 
 
-ABA:384 rdf:type owl:Class ;
+MBA:384 rdf:type owl:Class ;
 
         rdfs:label "trochlear nerve decussation"@en ;
 
         nsu:synonym "IVd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:911 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:911 ] .
 
 
 
-ABA:385 rdf:type owl:Class ;
+MBA:385 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area"@en ;
 
         nsu:synonym "VISp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:386 rdf:type owl:Class ;
+MBA:386 rdf:type owl:Class ;
 
         rdfs:label "Medulla, sensory related"@en ;
 
         nsu:synonym "MY-sen"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:354 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:354 ] .
 
 
 
-ABA:387 rdf:type owl:Class ;
+MBA:387 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 5/6"@en ;
 
         nsu:synonym "ENTl5/6"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:388 rdf:type owl:Class ;
+MBA:388 rdf:type owl:Class ;
 
         rdfs:label "gracile fascicle"@en ;
 
         nsu:synonym "grf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:514 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:514 ] .
 
 
 
-ABA:389 rdf:type owl:Class ;
+MBA:389 rdf:type owl:Class ;
 
         rdfs:label "ventral spinothalamic tract"@en ;
 
         nsu:synonym "sttv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:871 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:871 ] .
 
 
 
-ABA:39 rdf:type owl:Class ;
+MBA:39 rdf:type owl:Class ;
 
        rdfs:label "Anterior cingulate area, dorsal part"@en ;
 
        nsu:synonym "ACAd"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:390 rdf:type owl:Class ;
+MBA:390 rdf:type owl:Class ;
 
         rdfs:label "Supraoptic nucleus"@en ;
 
         nsu:synonym "SO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:157 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:157 ] .
 
 
 
-ABA:391 rdf:type owl:Class ;
+MBA:391 rdf:type owl:Class ;
 
         rdfs:label "Field CA1, stratum lacunosum-moleculare"@en ;
 
         nsu:synonym "CA1slm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:382 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:382 ] .
 
 
 
-ABA:392 rdf:type owl:Class ;
+MBA:392 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the lateral olfactory tract, layers 1-3"@en ;
 
         nsu:synonym "NLOT1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:619 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:619 ] .
 
 
 
-ABA:393 rdf:type owl:Class ;
+MBA:393 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 6b"@en ;
 
         nsu:synonym "VISpl6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:394 rdf:type owl:Class ;
+MBA:394 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial visual area"@en ;
 
         nsu:synonym "VISam"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:395 rdf:type owl:Class ;
+MBA:395 rdf:type owl:Class ;
 
         rdfs:label "Medullary reticular nucleus"@en ;
 
         nsu:synonym "MDRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:396 rdf:type owl:Class ;
+MBA:396 rdf:type owl:Class ;
 
         rdfs:label "internal arcuate fibers"@en ;
 
         nsu:synonym "iaf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:514 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:514 ] .
 
 
 
-ABA:397 rdf:type owl:Class ;
+MBA:397 rdf:type owl:Class ;
 
         rdfs:label "ventral tegmental decussation"@en ;
 
         nsu:synonym "vtd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:863 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:863 ] .
 
 
 
-ABA:398 rdf:type owl:Class ;
+MBA:398 rdf:type owl:Class ;
 
         rdfs:label "Superior olivary complex"@en ;
 
         nsu:synonym "SOC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1132 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1132 ] .
 
 
 
-ABA:399 rdf:type owl:Class ;
+MBA:399 rdf:type owl:Class ;
 
         rdfs:label "Field CA1, stratum oriens"@en ;
 
         nsu:synonym "CA1so"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:382 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:382 ] .
 
 
 
-ABA:4 rdf:type owl:Class ;
+MBA:4 rdf:type owl:Class ;
 
       rdfs:label "Inferior colliculus"@en ;
 
       nsu:synonym "IC"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:400 rdf:type owl:Class ;
+MBA:400 rdf:type owl:Class ;
 
         rdfs:label "Piriform-amygdalar area, layers 1-3"@en ;
 
         nsu:synonym "PAA1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:788 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:788 ] .
 
 
 
-ABA:401 rdf:type owl:Class ;
+MBA:401 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial visual area, layer 4"@en ;
 
         nsu:synonym "VISam4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:402 rdf:type owl:Class ;
+MBA:402 rdf:type owl:Class ;
 
         rdfs:label "Anterolateral visual area"@en ;
 
         nsu:synonym "VISal"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:403 rdf:type owl:Class ;
+MBA:403 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus"@en ;
 
         nsu:synonym "MEA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:278 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:278 ] .
 
 
 
-ABA:404 rdf:type owl:Class ;
+MBA:404 rdf:type owl:Class ;
 
         rdfs:label "olivocerebellar tract"@en ;
 
         nsu:synonym "oct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:490 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:490 ] .
 
 
 
-ABA:405 rdf:type owl:Class ;
+MBA:405 rdf:type owl:Class ;
 
         rdfs:label "ventrolateral hypothalamic tract"@en ;
 
         nsu:synonym "vlt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:406 rdf:type owl:Class ;
+MBA:406 rdf:type owl:Class ;
 
         rdfs:label "Subparafascicular nucleus"@en ;
 
         nsu:synonym "SPF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:864 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:864 ] .
 
 
 
-ABA:407 rdf:type owl:Class ;
+MBA:407 rdf:type owl:Class ;
 
         rdfs:label "Field CA1, pyramidal layer"@en ;
 
         nsu:synonym "CA1sp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:382 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:382 ] .
 
 
 
-ABA:408 rdf:type owl:Class ;
+MBA:408 rdf:type owl:Class ;
 
         rdfs:label "Piriform-amygdalar area, molecular layer"@en ;
 
         nsu:synonym "PAA1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:788 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:788 ] .
 
 
 
-ABA:409 rdf:type owl:Class ;
+MBA:409 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area"@en ;
 
         nsu:synonym "VISl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:41 rdf:type owl:Class ;
+MBA:41 rdf:type owl:Class ;
 
        rdfs:label "posteromedial visual area, layer 2/3"@en ;
 
        nsu:synonym "VISpm2/3"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:410 rdf:type owl:Class ;
+MBA:410 rdf:type owl:Class ;
 
         rdfs:label "reticulocerebellar tract"@en ;
 
         nsu:synonym "rct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:490 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:490 ] .
 
 
 
-ABA:411 rdf:type owl:Class ;
+MBA:411 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, anterodorsal part"@en ;
 
         nsu:synonym "MEAad"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:403 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:403 ] .
 
 
 
-ABA:412 rdf:type owl:Class ;
+MBA:412 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part, layer 2/3"@en ;
 
         nsu:synonym "ORBl2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:723 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:723 ] .
 
 
 
-ABA:413 rdf:type owl:Class ;
+MBA:413 rdf:type owl:Class ;
 
         rdfs:label "vestibular nerve"@en ;
 
         nsu:synonym "vVIIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:933 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:933 ] .
 
 
 
-ABA:414 rdf:type owl:Class ;
+MBA:414 rdf:type owl:Class ;
 
         rdfs:label "Subparafascicular nucleus, magnocellular part"@en ;
 
         nsu:synonym "SPFm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:406 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:406 ] .
 
 
 
-ABA:415 rdf:type owl:Class ;
+MBA:415 rdf:type owl:Class ;
 
         rdfs:label "Field CA1, stratum radiatum"@en ;
 
         nsu:synonym "CA1sr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:382 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:382 ] .
 
 
 
-ABA:416 rdf:type owl:Class ;
+MBA:416 rdf:type owl:Class ;
 
         rdfs:label "Piriform-amygdalar area, pyramidal layer"@en ;
 
         nsu:synonym "PAA2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:788 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:788 ] .
 
 
 
-ABA:418 rdf:type owl:Class ;
+MBA:418 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, anteroventral part"@en ;
 
         nsu:synonym "MEAav"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:403 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:403 ] .
 
 
 
-ABA:419 rdf:type owl:Class ;
+MBA:419 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, ventral zone, layer 4"@en ;
 
         nsu:synonym "ENTmv4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:934 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:934 ] .
 
 
 
-ABA:42 rdf:type owl:Class ;
+MBA:42 rdf:type owl:Class ;
 
        rdfs:label "Superior colliculus, motor related, deep white layer"@en ;
 
        nsu:synonym "SCdw"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:294 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:294 ] .
 
 
 
-ABA:420 rdf:type owl:Class ;
+MBA:420 rdf:type owl:Class ;
 
         rdfs:label "precommissural fornix diagonal band"@en ;
 
         nsu:synonym "db"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:745 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:745 ] .
 
 
 
-ABA:421 rdf:type owl:Class ;
+MBA:421 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area, layer 1"@en ;
 
         nsu:synonym "VISl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:422 rdf:type owl:Class ;
+MBA:422 rdf:type owl:Class ;
 
         rdfs:label "Subparafascicular nucleus, parvicellular part"@en ;
 
         nsu:synonym "SPFp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:406 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:406 ] .
 
 
 
-ABA:423 rdf:type owl:Class ;
+MBA:423 rdf:type owl:Class ;
 
         rdfs:label "Field CA2"@en ;
 
         nsu:synonym "CA2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:375 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:375 ] .
 
 
 
-ABA:424 rdf:type owl:Class ;
+MBA:424 rdf:type owl:Class ;
 
         rdfs:label "Piriform-amygdalar area, polymorph layer"@en ;
 
         nsu:synonym "PAA3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:788 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:788 ] .
 
 
 
-ABA:425 rdf:type owl:Class ;
+MBA:425 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area"@en ;
 
         nsu:synonym "VISpl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:426 rdf:type owl:Class ;
+MBA:426 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, posterodorsal part"@en ;
 
         nsu:synonym "MEApd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:403 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:403 ] .
 
 
 
-ABA:427 rdf:type owl:Class ;
+MBA:427 rdf:type owl:Class ;
 
         rdfs:label "Ectorhinal area/Layer 2/3"@en ;
 
         nsu:synonym "ECT2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:895 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:895 ] .
 
 
 
-ABA:428 rdf:type owl:Class ;
+MBA:428 rdf:type owl:Class ;
 
         rdfs:label "medial corticohypothalmic tract"@en ;
 
         nsu:synonym "mct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:737 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:737 ] .
 
 
 
-ABA:429 rdf:type owl:Class ;
+MBA:429 rdf:type owl:Class ;
 
         rdfs:label "Spinal nucleus of the trigeminal, caudal part"@en ;
 
         nsu:synonym "SPVC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:43 rdf:type owl:Class ;
+MBA:43 rdf:type owl:Class ;
 
        rdfs:label "ansoparamedian fissure"@en ;
 
        nsu:synonym "apf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:430 rdf:type owl:Class ;
+MBA:430 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 2/3"@en ;
 
         nsu:synonym "RSPv2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:431 rdf:type owl:Class ;
+MBA:431 rdf:type owl:Class ;
 
         rdfs:label "Field CA2, stratum lacunosum-moleculare"@en ;
 
         nsu:synonym "CA2slm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:423 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:423 ] .
 
 
 
-ABA:432 rdf:type owl:Class ;
+MBA:432 rdf:type owl:Class ;
 
         rdfs:label "Nucleus circularis"@en ;
 
         nsu:synonym "NC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:332 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:332 ] .
 
 
 
-ABA:433 rdf:type owl:Class ;
+MBA:433 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial visual area, layer 5"@en ;
 
         nsu:synonym "VISam5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:434 rdf:type owl:Class ;
+MBA:434 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 2/3"@en ;
 
         nsu:synonym "RSPd2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:435 rdf:type owl:Class ;
+MBA:435 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, posteroventral part"@en ;
 
         nsu:synonym "MEApv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:403 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:403 ] .
 
 
 
-ABA:436 rdf:type owl:Class ;
+MBA:436 rdf:type owl:Class ;
 
         rdfs:label "columns of the fornix"@en ;
 
         nsu:synonym "fx"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:737 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:737 ] .
 
 
 
-ABA:437 rdf:type owl:Class ;
+MBA:437 rdf:type owl:Class ;
 
         rdfs:label "Spinal nucleus of the trigeminal, interpolar part"@en ;
 
         nsu:synonym "SPVI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:438 rdf:type owl:Class ;
+MBA:438 rdf:type owl:Class ;
 
         rdfs:label "Field CA2, stratum oriens"@en ;
 
         nsu:synonym "CA2so"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:423 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:423 ] .
 
 
 
-ABA:439 rdf:type owl:Class ;
+MBA:439 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, descending division, dorsal parvicellular part"@en ;
 
         nsu:synonym "PVHdp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:63 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:63 ] .
 
 
 
-ABA:44 rdf:type owl:Class ;
+MBA:44 rdf:type owl:Class ;
 
        rdfs:label "Infralimbic area"@en ;
 
        nsu:synonym "ILA"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:440 rdf:type owl:Class ;
+MBA:440 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part, layer 6a"@en ;
 
         nsu:synonym "ORBl6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:723 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:723 ] .
 
 
 
-ABA:441 rdf:type owl:Class ;
+MBA:441 rdf:type owl:Class ;
 
         rdfs:label "Anteromedial visual area, layer 6b"@en ;
 
         nsu:synonym "VISam6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:394 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:394 ] .
 
 
 
-ABA:442 rdf:type owl:Class ;
+MBA:442 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 1"@en ;
 
         nsu:synonym "RSPd1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:443 rdf:type owl:Class ;
+MBA:443 rdf:type owl:Class ;
 
         rdfs:label "dorsal hippocampal commissure"@en ;
 
         nsu:synonym "dhc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:618 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:618 ] .
 
 
 
-ABA:444 rdf:type owl:Class ;
+MBA:444 rdf:type owl:Class ;
 
         rdfs:label "Medial group of the dorsal thalamus"@en ;
 
         nsu:synonym "MED"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:445 rdf:type owl:Class ;
+MBA:445 rdf:type owl:Class ;
 
         rdfs:label "Spinal nucleus of the trigeminal, oral part"@en ;
 
         nsu:synonym "SPVO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:446 rdf:type owl:Class ;
+MBA:446 rdf:type owl:Class ;
 
         rdfs:label "Field CA2, pyramidal layer"@en ;
 
         nsu:synonym "CA2sp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:423 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:423 ] .
 
 
 
-ABA:447 rdf:type owl:Class ;
+MBA:447 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, descending division, forniceal part"@en ;
 
         nsu:synonym "PVHf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:63 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:63 ] .
 
 
 
-ABA:448 rdf:type owl:Class ;
+MBA:448 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part, layer 1"@en ;
 
         nsu:synonym "ORBl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:723 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:723 ] .
 
 
 
-ABA:449 rdf:type owl:Class ;
+MBA:449 rdf:type owl:Class ;
 
         rdfs:label "ventral hippocampal commissure"@en ;
 
         nsu:synonym "vhc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:618 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:618 ] .
 
 
 
-ABA:45 rdf:type owl:Class ;
+MBA:45 rdf:type owl:Class ;
 
        rdfs:label "Spinal nucleus of the trigeminal, oral part, rostral dorsomedial part"@en ;
 
        nsu:synonym "SPVOrdm"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:445 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:445 ] .
 
 
 
-ABA:450 rdf:type owl:Class ;
+MBA:450 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb, layer 1"@en ;
 
         nsu:synonym "SSp-ul1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:451 rdf:type owl:Class ;
+MBA:451 rdf:type owl:Class ;
 
         rdfs:label "Basolateral amygdalar nucleus, ventral part"@en ;
 
         nsu:synonym "BLAv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:295 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:295 ] .
 
 
 
-ABA:452 rdf:type owl:Class ;
+MBA:452 rdf:type owl:Class ;
 
         rdfs:label "Median preoptic nucleus"@en ;
 
         nsu:synonym "MEPO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:453 rdf:type owl:Class ;
+MBA:453 rdf:type owl:Class ;
 
         rdfs:label "Somatosensory areas"@en ;
 
         nsu:synonym "SS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:454 rdf:type owl:Class ;
+MBA:454 rdf:type owl:Class ;
 
         rdfs:label "Field CA2, stratum radiatum"@en ;
 
         nsu:synonym "CA2sr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:423 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:423 ] .
 
 
 
-ABA:455 rdf:type owl:Class ;
+MBA:455 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, descending division, lateral parvicellular part"@en ;
 
         nsu:synonym "PVHlp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:63 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:63 ] .
 
 
 
-ABA:456 rdf:type owl:Class ;
+MBA:456 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 6b"@en ;
 
         nsu:synonym "AUDpo6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:457 rdf:type owl:Class ;
+MBA:457 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 6a"@en ;
 
         nsu:synonym "VIS6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:458 rdf:type owl:Class ;
+MBA:458 rdf:type owl:Class ;
 
         rdfs:label "Olfactory tubercle, molecular layer"@en ;
 
         nsu:synonym "OT1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:459 rdf:type owl:Class ;
+MBA:459 rdf:type owl:Class ;
 
         rdfs:label "accessory olfactory tract"@en ;
 
         nsu:synonym "aolt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:21 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:21 ] .
 
 
 
-ABA:46 rdf:type owl:Class ;
+MBA:46 rdf:type owl:Class ;
 
        rdfs:label "mammillary related"@en ;
 
        nsu:synonym "mfbsma"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:460 rdf:type owl:Class ;
+MBA:460 rdf:type owl:Class ;
 
         rdfs:label "Midbrain trigeminal nucleus"@en ;
 
         nsu:synonym "MEV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:461 rdf:type owl:Class ;
+MBA:461 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, trunk, layer 6b"@en ;
 
         nsu:synonym "SSp-tr6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:462 rdf:type owl:Class ;
+MBA:462 rdf:type owl:Class ;
 
         rdfs:label "Superior salivatory nucleus"@en ;
 
         nsu:synonym "SSN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:463 rdf:type owl:Class ;
+MBA:463 rdf:type owl:Class ;
 
         rdfs:label "Field CA3"@en ;
 
         nsu:synonym "CA3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:375 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:375 ] .
 
 
 
-ABA:464 rdf:type owl:Class ;
+MBA:464 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, descending division, medial parvicellular part, ventral zone"@en ;
 
         nsu:synonym "PVHmpv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:63 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:63 ] .
 
 
 
-ABA:465 rdf:type owl:Class ;
+MBA:465 rdf:type owl:Class ;
 
         rdfs:label "Olfactory tubercle, pyramidal layer"@en ;
 
         nsu:synonym "OT2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:466 rdf:type owl:Class ;
+MBA:466 rdf:type owl:Class ;
 
         rdfs:label "alveus"@en ;
 
         nsu:synonym "alv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:467 rdf:type owl:Class ;
+MBA:467 rdf:type owl:Class ;
 
         rdfs:label "Hypothalamic medial zone"@en ;
 
         nsu:synonym "MEZ"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1097 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1097 ] .
 
 
 
-ABA:468 rdf:type owl:Class ;
+MBA:468 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 2a"@en ;
 
         nsu:synonym "ENTm2a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:469 rdf:type owl:Class ;
+MBA:469 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area, layer 6b"@en ;
 
         nsu:synonym "VISpm6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:47 rdf:type owl:Class ;
+MBA:47 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division, anterior magnocellular part"@en ;
 
        nsu:synonym "PVHam"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:71 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:71 ] .
 
 
 
-ABA:470 rdf:type owl:Class ;
+MBA:470 rdf:type owl:Class ;
 
         rdfs:label "Subthalamic nucleus"@en ;
 
         nsu:synonym "STN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:471 rdf:type owl:Class ;
+MBA:471 rdf:type owl:Class ;
 
         rdfs:label "Field CA3, stratum lacunosum-moleculare"@en ;
 
         nsu:synonym "CA3slm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:463 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:463 ] .
 
 
 
-ABA:472 rdf:type owl:Class ;
+MBA:472 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, posterodorsal part, sublayer a"@en ;
 
         nsu:synonym "MEApd-a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:426 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:426 ] .
 
 
 
-ABA:473 rdf:type owl:Class ;
+MBA:473 rdf:type owl:Class ;
 
         rdfs:label "Olfactory tubercle, polymorph layer"@en ;
 
         nsu:synonym "OT3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:474 rdf:type owl:Class ;
+MBA:474 rdf:type owl:Class ;
 
         rdfs:label "angular path"@en ;
 
         nsu:synonym "ab"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:475 rdf:type owl:Class ;
+MBA:475 rdf:type owl:Class ;
 
         rdfs:label "Medial geniculate complex"@en ;
 
         nsu:synonym "MG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1008 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1008 ] .
 
 
 
-ABA:476 rdf:type owl:Class ;
+MBA:476 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, layer 6a"@en ;
 
         nsu:synonym "ORB6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:477 rdf:type owl:Class ;
+MBA:477 rdf:type owl:Class ;
 
         rdfs:label "Striatum"@en ;
 
         nsu:synonym "STR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:623 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:623 ] .
 
 
 
-ABA:478 rdf:type owl:Class ;
+MBA:478 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, lower limb, layer 6a"@en ;
 
         nsu:synonym "SSp-ll6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:479 rdf:type owl:Class ;
+MBA:479 rdf:type owl:Class ;
 
         rdfs:label "Field CA3, stratum lucidum"@en ;
 
         nsu:synonym "CA3slu"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:463 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:463 ] .
 
 
 
-ABA:48 rdf:type owl:Class ;
+MBA:48 rdf:type owl:Class ;
 
        rdfs:label "Anterior cingulate area, ventral part"@en ;
 
        nsu:synonym "ACAv"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:480 rdf:type owl:Class ;
+MBA:480 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, posterodorsal part, sublayer b"@en ;
 
         nsu:synonym "MEApd-b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:426 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:426 ] .
 
 
 
-ABA:481 rdf:type owl:Class ;
+MBA:481 rdf:type owl:Class ;
 
         rdfs:label "Islands of Calleja"@en ;
 
         nsu:synonym "isl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:482 rdf:type owl:Class ;
+MBA:482 rdf:type owl:Class ;
 
         rdfs:label "brachium of the inferior colliculus"@en ;
 
         nsu:synonym "bic"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:483 rdf:type owl:Class ;
+MBA:483 rdf:type owl:Class ;
 
         rdfs:label "Medial habenula"@en ;
 
         nsu:synonym "MH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:958 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:958 ] .
 
 
 
-ABA:484 rdf:type owl:Class ;
+MBA:484 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part, layer 1"@en ;
 
         nsu:synonym "ORBm1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:731 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:731 ] .
 
 
 
-ABA:485 rdf:type owl:Class ;
+MBA:485 rdf:type owl:Class ;
 
         rdfs:label "Striatum dorsal region"@en ;
 
         nsu:synonym "STRd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:477 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:477 ] .
 
 
 
-ABA:486 rdf:type owl:Class ;
+MBA:486 rdf:type owl:Class ;
 
         rdfs:label "Field CA3, stratum oriens"@en ;
 
         nsu:synonym "CA3so"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:463 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:463 ] .
 
 
 
-ABA:487 rdf:type owl:Class ;
+MBA:487 rdf:type owl:Class ;
 
         rdfs:label "Medial amygdalar nucleus, posterodorsal part, sublayer c"@en ;
 
         nsu:synonym "MEApd-c"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:426 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:426 ] .
 
 
 
-ABA:488 rdf:type owl:Class ;
+MBA:488 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part, layer 6b"@en ;
 
         nsu:synonym "ORBl6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:723 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:723 ] .
 
 
 
-ABA:489 rdf:type owl:Class ;
+MBA:489 rdf:type owl:Class ;
 
         rdfs:label "Major island of Calleja"@en ;
 
         nsu:synonym "islm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:754 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:754 ] .
 
 
 
-ABA:49 rdf:type owl:Class ;
+MBA:49 rdf:type owl:Class ;
 
        rdfs:label "intraparafloccular fissure"@en ;
 
        nsu:synonym "ipf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:490 rdf:type owl:Class ;
+MBA:490 rdf:type owl:Class ;
 
         rdfs:label "bulbocerebellar tract"@en ;
 
         nsu:synonym "bct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1123 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1123 ] .
 
 
 
-ABA:491 rdf:type owl:Class ;
+MBA:491 rdf:type owl:Class ;
 
         rdfs:label "Medial mammillary nucleus"@en ;
 
         nsu:synonym "MM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:331 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:331 ] .
 
 
 
-ABA:492 rdf:type owl:Class ;
+MBA:492 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, layer 2/3"@en ;
 
         nsu:synonym "ORB2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:493 rdf:type owl:Class ;
+MBA:493 rdf:type owl:Class ;
 
         rdfs:label "Striatum ventral region"@en ;
 
         nsu:synonym "STRv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:477 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:477 ] .
 
 
 
-ABA:494 rdf:type owl:Class ;
+MBA:494 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, motor related, intermediate gray layer, sublayer a"@en ;
 
         nsu:synonym "SCig-a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:10 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:10 ] .
 
 
 
-ABA:495 rdf:type owl:Class ;
+MBA:495 rdf:type owl:Class ;
 
         rdfs:label "Field CA3, pyramidal layer"@en ;
 
         nsu:synonym "CA3sp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:463 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:463 ] .
 
 
 
-ABA:496 rdf:type owl:Class ;
+MBA:496 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area, layer 1"@en ;
 
         nsu:synonym "DP1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:814 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:814 ] .
 
 
 
-ABA:497 rdf:type owl:Class ;
+MBA:497 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 6b"@en ;
 
         nsu:synonym "VIS6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:498 rdf:type owl:Class ;
+MBA:498 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, anteromedial area"@en ;
 
         nsu:synonym "BSTam"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:499 rdf:type owl:Class ;
+MBA:499 rdf:type owl:Class ;
 
         rdfs:label "cuneocerebellar tract"@en ;
 
         nsu:synonym "cct"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1123 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1123 ] .
 
 
 
-ABA:50 rdf:type owl:Class ;
+MBA:50 rdf:type owl:Class ;
 
        rdfs:label "Precommissural nucleus"@en ;
 
        nsu:synonym "PRC"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:795 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:795 ] .
 
 
 
-ABA:500 rdf:type owl:Class ;
+MBA:500 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas"@en ;
 
         nsu:synonym "MO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:501 rdf:type owl:Class ;
+MBA:501 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area, layer 4"@en ;
 
         nsu:synonym "VISpm4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:502 rdf:type owl:Class ;
+MBA:502 rdf:type owl:Class ;
 
         rdfs:label "Subiculum"@en ;
 
         nsu:synonym "SUB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:822 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:822 ] .
 
 
 
-ABA:503 rdf:type owl:Class ;
+MBA:503 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, motor related, intermediate gray layer, sublayer b"@en ;
 
         nsu:synonym "SCig-b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:10 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:10 ] .
 
 
 
-ABA:504 rdf:type owl:Class ;
+MBA:504 rdf:type owl:Class ;
 
         rdfs:label "Field CA3, stratum radiatum"@en ;
 
         nsu:synonym "CA3sr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:463 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:463 ] .
 
 
 
-ABA:505 rdf:type owl:Class ;
+MBA:505 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, dorsomedial nucleus"@en ;
 
         nsu:synonym "BSTdm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:506 rdf:type owl:Class ;
+MBA:506 rdf:type owl:Class ;
 
         rdfs:label "dorsal acoustic stria"@en ;
 
         nsu:synonym "das"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:507 rdf:type owl:Class ;
+MBA:507 rdf:type owl:Class ;
 
         rdfs:label "Main olfactory bulb"@en ;
 
         nsu:synonym "MOB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:508 rdf:type owl:Class ;
+MBA:508 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 2b"@en ;
 
         nsu:synonym "ENTm2b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:509 rdf:type owl:Class ;
+MBA:509 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, dorsal part"@en ;
 
         nsu:synonym "SUBd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:502 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:502 ] .
 
 
 
-ABA:51 rdf:type owl:Class ;
+MBA:51 rdf:type owl:Class ;
 
        rdfs:label "Intralaminar nuclei of the dorsal thalamus"@en ;
 
        nsu:synonym "ILM"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:510 rdf:type owl:Class ;
+MBA:510 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, lower limb, layer 6b"@en ;
 
         nsu:synonym "SSp-ll6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:337 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:337 ] .
 
 
 
-ABA:511 rdf:type owl:Class ;
+MBA:511 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, motor related, intermediate gray layer, sublayer c"@en ;
 
         nsu:synonym "SCig-c"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:10 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:10 ] .
 
 
 
-ABA:512 rdf:type owl:Class ;
+MBA:512 rdf:type owl:Class ;
 
         rdfs:label "Cerebellum"@en ;
 
         nsu:synonym "CB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:8 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:8 ] .
 
 
 
-ABA:513 rdf:type owl:Class ;
+MBA:513 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, fusiform nucleus"@en ;
 
         nsu:synonym "BSTfu"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:514 rdf:type owl:Class ;
+MBA:514 rdf:type owl:Class ;
 
         rdfs:label "dorsal column"@en ;
 
         nsu:synonym "dc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:515 rdf:type owl:Class ;
+MBA:515 rdf:type owl:Class ;
 
         rdfs:label "Medial preoptic nucleus"@en ;
 
         nsu:synonym "MPN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:516 rdf:type owl:Class ;
+MBA:516 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, layer 6b"@en ;
 
         nsu:synonym "ORB6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:517 rdf:type owl:Class ;
+MBA:517 rdf:type owl:Class ;
 
         rdfs:label "Postpiriform transition area, layers 1-3"@en ;
 
         nsu:synonym "TR1-3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:566 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:566 ] .
 
 
 
-ABA:518 rdf:type owl:Class ;
+MBA:518 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, ventral part"@en ;
 
         nsu:synonym "SUBv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:502 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:502 ] .
 
 
 
-ABA:519 rdf:type owl:Class ;
+MBA:519 rdf:type owl:Class ;
 
         rdfs:label "Cerebellar nuclei"@en ;
 
         nsu:synonym "CBN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:512 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:512 ] .
 
 
 
-ABA:52 rdf:type owl:Class ;
+MBA:52 rdf:type owl:Class ;
 
        rdfs:label "Entorhinal area, lateral part, layer 3"@en ;
 
        nsu:synonym "ENTl3"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:520 rdf:type owl:Class ;
+MBA:520 rdf:type owl:Class ;
 
         rdfs:label "Ventral auditory area, layer 6a"@en ;
 
         nsu:synonym "AUDv6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:521 rdf:type owl:Class ;
+MBA:521 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, magnocellular nucleus"@en ;
 
         nsu:synonym "BSTmg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:522 rdf:type owl:Class ;
+MBA:522 rdf:type owl:Class ;
 
         rdfs:label "dorsal commissure of the spinal cord"@en ;
 
         nsu:synonym "dcm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:523 rdf:type owl:Class ;
+MBA:523 rdf:type owl:Class ;
 
         rdfs:label "Medial preoptic area"@en ;
 
         nsu:synonym "MPO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:524 rdf:type owl:Class ;
+MBA:524 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part, layer 2"@en ;
 
         nsu:synonym "ORBm2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:731 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:731 ] .
 
 
 
-ABA:525 rdf:type owl:Class ;
+MBA:525 rdf:type owl:Class ;
 
         rdfs:label "Supramammillary nucleus"@en ;
 
         nsu:synonym "SUM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:331 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:331 ] .
 
 
 
-ABA:526 rdf:type owl:Class ;
+MBA:526 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 1"@en ;
 
         nsu:synonym "ENTm1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:527 rdf:type owl:Class ;
+MBA:527 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 1"@en ;
 
         nsu:synonym "AUDd1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:528 rdf:type owl:Class ;
+MBA:528 rdf:type owl:Class ;
 
         rdfs:label "Cerebellar cortex"@en ;
 
         nsu:synonym "CBX"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:512 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:512 ] .
 
 
 
-ABA:529 rdf:type owl:Class ;
+MBA:529 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, ventral nucleus"@en ;
 
         nsu:synonym "BSTv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:53 rdf:type owl:Class ;
+MBA:53 rdf:type owl:Class ;
 
        rdfs:label "Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, dorsal zone"@en ;
 
        nsu:synonym "SPVOmdmd"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:445 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:445 ] .
 
 
 
-ABA:530 rdf:type owl:Class ;
+MBA:530 rdf:type owl:Class ;
 
         rdfs:label "dorsal fornix"@en ;
 
         nsu:synonym "df"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:531 rdf:type owl:Class ;
+MBA:531 rdf:type owl:Class ;
 
         rdfs:label "Medial pretectal area"@en ;
 
         nsu:synonym "MPT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:532 rdf:type owl:Class ;
+MBA:532 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 1"@en ;
 
         nsu:synonym "PTLp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:533 rdf:type owl:Class ;
+MBA:533 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area"@en ;
 
         nsu:synonym "VISpm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:534 rdf:type owl:Class ;
+MBA:534 rdf:type owl:Class ;
 
         rdfs:label "Supratrigeminal nucleus"@en ;
 
         nsu:synonym "SUT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:535 rdf:type owl:Class ;
+MBA:535 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area, layer 2"@en ;
 
         nsu:synonym "DP2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:814 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:814 ] .
 
 
 
-ABA:536 rdf:type owl:Class ;
+MBA:536 rdf:type owl:Class ;
 
         rdfs:label "Central amygdalar nucleus"@en ;
 
         nsu:synonym "CEA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:278 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:278 ] .
 
 
 
-ABA:537 rdf:type owl:Class ;
+MBA:537 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, anterolateral area"@en ;
 
         nsu:synonym "BSTal"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:538 rdf:type owl:Class ;
+MBA:538 rdf:type owl:Class ;
 
         rdfs:label "dorsal limb"@en ;
 
         nsu:synonym "lotd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:21 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:21 ] .
 
 
 
-ABA:539 rdf:type owl:Class ;
+MBA:539 rdf:type owl:Class ;
 
         rdfs:label "Midbrain reticular nucleus, magnocellular part"@en ;
 
         nsu:synonym "MRNm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:128 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:128 ] .
 
 
 
-ABA:54 rdf:type owl:Class ;
+MBA:54 rdf:type owl:Class ;
 
        rdfs:label "medial forebrain bundle"@en ;
 
        nsu:synonym "mfb"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:540 rdf:type owl:Class ;
+MBA:540 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area, layer 1"@en ;
 
         nsu:synonym "PERI1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:922 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:922 ] .
 
 
 
-ABA:541 rdf:type owl:Class ;
+MBA:541 rdf:type owl:Class ;
 
         rdfs:label "Temporal association areas"@en ;
 
         nsu:synonym "TEa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:542 rdf:type owl:Class ;
+MBA:542 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 1"@en ;
 
         nsu:synonym "RSPv1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:543 rdf:type owl:Class ;
+MBA:543 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 2"@en ;
 
         nsu:synonym "ENTm2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:544 rdf:type owl:Class ;
+MBA:544 rdf:type owl:Class ;
 
         rdfs:label "Central amygdalar nucleus, capsular part"@en ;
 
         nsu:synonym "CEAc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:536 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:536 ] .
 
 
 
-ABA:545 rdf:type owl:Class ;
+MBA:545 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 4"@en ;
 
         nsu:synonym "RSPd4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:546 rdf:type owl:Class ;
+MBA:546 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, juxtacapsular nucleus"@en ;
 
         nsu:synonym "BSTju"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:547 rdf:type owl:Class ;
+MBA:547 rdf:type owl:Class ;
 
         rdfs:label "dorsal longitudinal fascicle"@en ;
 
         nsu:synonym "dlf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:70 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:70 ] .
 
 
 
-ABA:548 rdf:type owl:Class ;
+MBA:548 rdf:type owl:Class ;
 
         rdfs:label "Midbrain reticular nucleus, magnocellular part, general"@en ;
 
         nsu:synonym "MRNmg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:128 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:128 ] .
 
 
 
-ABA:549 rdf:type owl:Class ;
+MBA:549 rdf:type owl:Class ;
 
         rdfs:label "Thalamus"@en ;
 
         nsu:synonym "TH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1129 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1129 ] .
 
 
 
-ABA:55 rdf:type owl:Class ;
+MBA:55 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, parvicellular division, anterior parvicellular part"@en ;
 
        nsu:synonym "PVHap"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:94 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:94 ] .
 
 
 
-ABA:550 rdf:type owl:Class ;
+MBA:550 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 5/6"@en ;
 
         nsu:synonym "ENTm5/6"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:551 rdf:type owl:Class ;
+MBA:551 rdf:type owl:Class ;
 
         rdfs:label "Central amygdalar nucleus, lateral part"@en ;
 
         nsu:synonym "CEAl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:536 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:536 ] .
 
 
 
-ABA:552 rdf:type owl:Class ;
+MBA:552 rdf:type owl:Class ;
 
         rdfs:label "Pontine reticular nucleus, ventral part"@en ;
 
         nsu:synonym "PRNv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:553 rdf:type owl:Class ;
+MBA:553 rdf:type owl:Class ;
 
         rdfs:label "dorsal spinocerebellar tract"@en ;
 
         nsu:synonym "sctd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1123 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1123 ] .
 
 
 
-ABA:554 rdf:type owl:Class ;
+MBA:554 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, oval nucleus"@en ;
 
         nsu:synonym "BSTov"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:555 rdf:type owl:Class ;
+MBA:555 rdf:type owl:Class ;
 
         rdfs:label "Midbrain reticular nucleus, parvicellular part"@en ;
 
         nsu:synonym "MRNp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:128 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:128 ] .
 
 
 
-ABA:556 rdf:type owl:Class ;
+MBA:556 rdf:type owl:Class ;
 
         rdfs:label "Infralimbic area, layer 2/3"@en ;
 
         nsu:synonym "ILA2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:557 rdf:type owl:Class ;
+MBA:557 rdf:type owl:Class ;
 
         rdfs:label "Tuberomammillary nucleus"@en ;
 
         nsu:synonym "TM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:331 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:331 ] .
 
 
 
-ABA:558 rdf:type owl:Class ;
+MBA:558 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 1"@en ;
 
         nsu:synonym "SSp-n1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:559 rdf:type owl:Class ;
+MBA:559 rdf:type owl:Class ;
 
         rdfs:label "Central amygdalar nucleus, medial part"@en ;
 
         nsu:synonym "CEAm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:536 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:536 ] .
 
 
 
-ABA:56 rdf:type owl:Class ;
+MBA:56 rdf:type owl:Class ;
 
        rdfs:label "Nucleus accumbens"@en ;
 
        nsu:synonym "ACB"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:493 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:493 ] .
 
 
 
-ABA:560 rdf:type owl:Class ;
+MBA:560 rdf:type owl:Class ;
 
         rdfs:label "Cochlear nucleus, subpedunclular granular region"@en ;
 
         nsu:synonym "CNspg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:607 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:607 ] .
 
 
 
-ABA:561 rdf:type owl:Class ;
+MBA:561 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 2/3"@en ;
 
         nsu:synonym "VIS2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:562 rdf:type owl:Class ;
+MBA:562 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, anterior division, rhomboid nucleus"@en ;
 
         nsu:synonym "BSTrh"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:359 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:359 ] .
 
 
 
-ABA:563 rdf:type owl:Class ;
+MBA:563 rdf:type owl:Class ;
 
         rdfs:label "dorsal tegmental tract"@en ;
 
         nsu:synonym "dtt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:70 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:70 ] .
 
 
 
-ABA:564 rdf:type owl:Class ;
+MBA:564 rdf:type owl:Class ;
 
         rdfs:label "Medial septal nucleus"@en ;
 
         nsu:synonym "MS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:904 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:904 ] .
 
 
 
-ABA:565 rdf:type owl:Class ;
+MBA:565 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area, layer 5"@en ;
 
         nsu:synonym "VISpm5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:566 rdf:type owl:Class ;
+MBA:566 rdf:type owl:Class ;
 
         rdfs:label "Postpiriform transition area"@en ;
 
         nsu:synonym "TR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:567 rdf:type owl:Class ;
+MBA:567 rdf:type owl:Class ;
 
         rdfs:label "Cerebrum"@en ;
 
         nsu:synonym "CH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:8 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:8 ] .
 
 
 
-ABA:568 rdf:type owl:Class ;
+MBA:568 rdf:type owl:Class ;
 
         rdfs:label "Accessory abducens nucleus"@en ;
 
         nsu:synonym "ACVI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:569 rdf:type owl:Class ;
+MBA:569 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division, dorsal nucleus"@en ;
 
         nsu:synonym "BSTd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:367 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:367 ] .
 
 
 
-ABA:57 rdf:type owl:Class ;
+MBA:57 rdf:type owl:Class ;
 
        rdfs:label "paramedian sulcus"@en ;
 
        nsu:synonym "pms"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:570 rdf:type owl:Class ;
+MBA:570 rdf:type owl:Class ;
 
         rdfs:label "dorsolateral fascicle"@en ;
 
         nsu:synonym "dl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:571 rdf:type owl:Class ;
+MBA:571 rdf:type owl:Class ;
 
         rdfs:label "Midline group of the dorsal thalamus"@en ;
 
         nsu:synonym "MTN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:572 rdf:type owl:Class ;
+MBA:572 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, layer 1"@en ;
 
         nsu:synonym "ACA1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:573 rdf:type owl:Class ;
+MBA:573 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area, layer 4"@en ;
 
         nsu:synonym "VISl4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:574 rdf:type owl:Class ;
+MBA:574 rdf:type owl:Class ;
 
         rdfs:label "Tegmental reticular nucleus"@en ;
 
         nsu:synonym "TRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:575 rdf:type owl:Class ;
+MBA:575 rdf:type owl:Class ;
 
         rdfs:label "Central lateral nucleus of the thalamus"@en ;
 
         nsu:synonym "CL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:51 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:51 ] .
 
 
 
-ABA:576 rdf:type owl:Class ;
+MBA:576 rdf:type owl:Class ;
 
         rdfs:label "Accessory facial motor nucleus"@en ;
 
         nsu:synonym "ACVII"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:577 rdf:type owl:Class ;
+MBA:577 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb, layer 4"@en ;
 
         nsu:synonym "SSp-ul4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:578 rdf:type owl:Class ;
+MBA:578 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division, principal nucleus"@en ;
 
         nsu:synonym "BSTpr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:367 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:367 ] .
 
 
 
-ABA:579 rdf:type owl:Class ;
+MBA:579 rdf:type owl:Class ;
 
         rdfs:label "external capsule"@en ;
 
         nsu:synonym "ec"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:956 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:956 ] .
 
 
 
-ABA:58 rdf:type owl:Class ;
+MBA:58 rdf:type owl:Class ;
 
        rdfs:label "Medial terminal nucleus of the accessory optic tract"@en ;
 
        nsu:synonym "MT"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:580 rdf:type owl:Class ;
+MBA:580 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the brachium of the inferior colliculus"@en ;
 
         nsu:synonym "NB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:581 rdf:type owl:Class ;
+MBA:581 rdf:type owl:Class ;
 
         rdfs:label "Triangular nucleus of septum"@en ;
 
         nsu:synonym "TRS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:826 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:826 ] .
 
 
 
-ABA:582 rdf:type owl:Class ;
+MBA:582 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part, layer 2/3"@en ;
 
         nsu:synonym "ORBm2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:731 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:731 ] .
 
 
 
-ABA:583 rdf:type owl:Class ;
+MBA:583 rdf:type owl:Class ;
 
         rdfs:label "Claustrum"@en ;
 
         nsu:synonym "CLA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:584 rdf:type owl:Class ;
+MBA:584 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone, layers 1-2"@en ;
 
         nsu:synonym "COApl1-2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:655 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:655 ] .
 
 
 
-ABA:585 rdf:type owl:Class ;
+MBA:585 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division, interfascicular nucleus"@en ;
 
         nsu:synonym "BSTif"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:367 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:367 ] .
 
 
 
-ABA:586 rdf:type owl:Class ;
+MBA:586 rdf:type owl:Class ;
 
         rdfs:label "fasciculus proprius"@en ;
 
         nsu:synonym "fpr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:587 rdf:type owl:Class ;
+MBA:587 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of Darkschewitsch"@en ;
 
         nsu:synonym "ND"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:795 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:795 ] .
 
 
 
-ABA:588 rdf:type owl:Class ;
+MBA:588 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, ventral part, layer 1"@en ;
 
         nsu:synonym "ACAv1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:48 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:48 ] .
 
 
 
-ABA:589 rdf:type owl:Class ;
+MBA:589 rdf:type owl:Class ;
 
         rdfs:label "Taenia tecta"@en ;
 
         nsu:synonym "TT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:59 rdf:type owl:Class ;
+MBA:59 rdf:type owl:Class ;
 
        rdfs:label "Intermediodorsal nucleus of the thalamus"@en ;
 
        nsu:synonym "IMD"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:444 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:444 ] .
 
 
 
-ABA:590 rdf:type owl:Class ;
+MBA:590 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 6a"@en ;
 
         nsu:synonym "RSPv6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:591 rdf:type owl:Class ;
+MBA:591 rdf:type owl:Class ;
 
         rdfs:label "Central linear nucleus raphe"@en ;
 
         nsu:synonym "CLI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:165 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:165 ] .
 
 
 
-ABA:592 rdf:type owl:Class ;
+MBA:592 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone, layers 1-2"@en ;
 
         nsu:synonym "COApm1-2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:663 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:663 ] .
 
 
 
-ABA:593 rdf:type owl:Class ;
+MBA:593 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area, layer 1"@en ;
 
         nsu:synonym "VISp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:594 rdf:type owl:Class ;
+MBA:594 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division, transverse nucleus"@en ;
 
         nsu:synonym "BSTtr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:367 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:367 ] .
 
 
 
-ABA:595 rdf:type owl:Class ;
+MBA:595 rdf:type owl:Class ;
 
         rdfs:label "fasciculus retroflexus"@en ;
 
         nsu:synonym "fr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1083 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1083 ] .
 
 
 
-ABA:596 rdf:type owl:Class ;
+MBA:596 rdf:type owl:Class ;
 
         rdfs:label "Diagonal band nucleus"@en ;
 
         nsu:synonym "NDB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:904 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:904 ] .
 
 
 
-ABA:597 rdf:type owl:Class ;
+MBA:597 rdf:type owl:Class ;
 
         rdfs:label "Taenia tecta, dorsal part"@en ;
 
         nsu:synonym "TTd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:589 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:589 ] .
 
 
 
-ABA:598 rdf:type owl:Class ;
+MBA:598 rdf:type owl:Class ;
 
         rdfs:label "Ventral auditory area, layer 6b"@en ;
 
         nsu:synonym "AUDv6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:599 rdf:type owl:Class ;
+MBA:599 rdf:type owl:Class ;
 
         rdfs:label "Central medial nucleus of the thalamus"@en ;
 
         nsu:synonym "CM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:51 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:51 ] .
 
 
 
-ABA:6 rdf:type owl:Class ;
+MBA:6 rdf:type owl:Class ;
 
       rdfs:label "internal capsule"@en ;
 
       nsu:synonym "int"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:60 rdf:type owl:Class ;
+MBA:60 rdf:type owl:Class ;
 
        rdfs:label "Entorhinal area, lateral part, layer 6b"@en ;
 
        nsu:synonym "ENTl6b"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:600 rdf:type owl:Class ;
+MBA:600 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 2/3"@en ;
 
         nsu:synonym "AUDd2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:601 rdf:type owl:Class ;
+MBA:601 rdf:type owl:Class ;
 
         rdfs:label "Anterolateral visual area, layer 6a"@en ;
 
         nsu:synonym "VISal6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:602 rdf:type owl:Class ;
+MBA:602 rdf:type owl:Class ;
 
         rdfs:label "Bed nuclei of the stria terminalis, posterior division, strial extension"@en ;
 
         nsu:synonym "BSTse"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:367 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:367 ] .
 
 
 
-ABA:603 rdf:type owl:Class ;
+MBA:603 rdf:type owl:Class ;
 
         rdfs:label "fimbria"@en ;
 
         nsu:synonym "fi"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:604 rdf:type owl:Class ;
+MBA:604 rdf:type owl:Class ;
 
         rdfs:label "Nucleus incertus"@en ;
 
         nsu:synonym "NI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:605 rdf:type owl:Class ;
+MBA:605 rdf:type owl:Class ;
 
         rdfs:label "Taenia tecta, ventral part"@en ;
 
         nsu:synonym "TTv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:589 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:589 ] .
 
 
 
-ABA:606 rdf:type owl:Class ;
+MBA:606 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 2"@en ;
 
         nsu:synonym "RSPv2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:607 rdf:type owl:Class ;
+MBA:607 rdf:type owl:Class ;
 
         rdfs:label "Cochlear nuclei"@en ;
 
         nsu:synonym "CN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:608 rdf:type owl:Class ;
+MBA:608 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventrolateral part, layer 6a"@en ;
 
         nsu:synonym "ORBvl6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:746 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:746 ] .
 
 
 
-ABA:609 rdf:type owl:Class ;
+MBA:609 rdf:type owl:Class ;
 
         rdfs:label "Subparafascicular area"@en ;
 
         nsu:synonym "SPA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:864 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:864 ] .
 
 
 
-ABA:61 rdf:type owl:Class ;
+MBA:61 rdf:type owl:Class ;
 
        rdfs:label "Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, ventral zone"@en ;
 
        nsu:synonym "SPVOmdmv"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:445 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:445 ] .
 
 
 
-ABA:610 rdf:type owl:Class ;
+MBA:610 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part, layer 5"@en ;
 
         nsu:synonym "RSPd5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:879 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:879 ] .
 
 
 
-ABA:611 rdf:type owl:Class ;
+MBA:611 rdf:type owl:Class ;
 
         rdfs:label "habenular commissure"@en ;
 
         nsu:synonym "hbc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1083 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1083 ] .
 
 
 
-ABA:612 rdf:type owl:Class ;
+MBA:612 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the lateral lemniscus"@en ;
 
         nsu:synonym "NLL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1132 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1132 ] .
 
 
 
-ABA:613 rdf:type owl:Class ;
+MBA:613 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area, layer 5"@en ;
 
         nsu:synonym "VISl5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:614 rdf:type owl:Class ;
+MBA:614 rdf:type owl:Class ;
 
         rdfs:label "Tuberal nucleus"@en ;
 
         nsu:synonym "TU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:615 rdf:type owl:Class ;
+MBA:615 rdf:type owl:Class ;
 
         rdfs:label "Substantia nigra, lateral part"@en ;
 
         nsu:synonym "SNl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:616 rdf:type owl:Class ;
+MBA:616 rdf:type owl:Class ;
 
         rdfs:label "Cuneiform nucleus"@en ;
 
         nsu:synonym "CUN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:617 rdf:type owl:Class ;
+MBA:617 rdf:type owl:Class ;
 
         rdfs:label "Mediodorsal nucleus of the thalamus, central part"@en ;
 
         nsu:synonym "MDc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:362 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:362 ] .
 
 
 
-ABA:618 rdf:type owl:Class ;
+MBA:618 rdf:type owl:Class ;
 
         rdfs:label "hippocampal commissures"@en ;
 
         nsu:synonym "hc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:619 rdf:type owl:Class ;
+MBA:619 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the lateral olfactory tract"@en ;
 
         nsu:synonym "NLOT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:62 rdf:type owl:Class ;
+MBA:62 rdf:type owl:Class ;
 
        rdfs:label "medial longitudinal fascicle"@en ;
 
        nsu:synonym "mlf"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:832 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:832 ] .
 
 
 
-ABA:620 rdf:type owl:Class ;
+MBA:620 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part, layer 5"@en ;
 
         nsu:synonym "ORBm5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:731 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:731 ] .
 
 
 
-ABA:621 rdf:type owl:Class ;
+MBA:621 rdf:type owl:Class ;
 
         rdfs:label "Motor nucleus of trigeminal"@en ;
 
         nsu:synonym "V"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:622 rdf:type owl:Class ;
+MBA:622 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 6b"@en ;
 
         nsu:synonym "RSPv6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:623 rdf:type owl:Class ;
+MBA:623 rdf:type owl:Class ;
 
         rdfs:label "Cerebral nuclei"@en ;
 
         nsu:synonym "CNU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:567 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:567 ] .
 
 
 
-ABA:624 rdf:type owl:Class ;
+MBA:624 rdf:type owl:Class ;
 
         rdfs:label "Interpeduncular fossa"@en ;
 
         nsu:synonym "IPF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1024 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1024 ] .
 
 
 
-ABA:625 rdf:type owl:Class ;
+MBA:625 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb, layer 5"@en ;
 
         nsu:synonym "SSp-ul5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:626 rdf:type owl:Class ;
+MBA:626 rdf:type owl:Class ;
 
         rdfs:label "Mediodorsal nucleus of the thalamus, lateral part"@en ;
 
         nsu:synonym "MDl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:362 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:362 ] .
 
 
 
-ABA:627 rdf:type owl:Class ;
+MBA:627 rdf:type owl:Class ;
 
         rdfs:label "hypothalamohypophysial tract"@en ;
 
         nsu:synonym "hht"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:285 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:285 ] .
 
 
 
-ABA:628 rdf:type owl:Class ;
+MBA:628 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the optic tract"@en ;
 
         nsu:synonym "NOT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:629 rdf:type owl:Class ;
+MBA:629 rdf:type owl:Class ;
 
         rdfs:label "Ventral anterior-lateral complex of the thalamus"@en ;
 
         nsu:synonym "VAL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:637 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:637 ] .
 
 
 
-ABA:63 rdf:type owl:Class ;
+MBA:63 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, descending division"@en ;
 
        nsu:synonym "PVHd"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:630 rdf:type owl:Class ;
+MBA:630 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part, layer 5"@en ;
 
         nsu:synonym "ORBl5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:723 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:723 ] .
 
 
 
-ABA:631 rdf:type owl:Class ;
+MBA:631 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area"@en ;
 
         nsu:synonym "COA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:632 rdf:type owl:Class ;
+MBA:632 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus, granule cell layer"@en ;
 
         nsu:synonym "DG-sg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:633 rdf:type owl:Class ;
+MBA:633 rdf:type owl:Class ;
 
         rdfs:label "inferior colliculus commissure"@en ;
 
         nsu:synonym "cic"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:634 rdf:type owl:Class ;
+MBA:634 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the posterior commissure"@en ;
 
         nsu:synonym "NPC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:635 rdf:type owl:Class ;
+MBA:635 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 4"@en ;
 
         nsu:synonym "PTLp4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:636 rdf:type owl:Class ;
+MBA:636 rdf:type owl:Class ;
 
         rdfs:label "Mediodorsal nucleus of the thalamus, medial part"@en ;
 
         nsu:synonym "MDm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:362 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:362 ] .
 
 
 
-ABA:637 rdf:type owl:Class ;
+MBA:637 rdf:type owl:Class ;
 
         rdfs:label "Ventral group of the dorsal thalamus"@en ;
 
         nsu:synonym "VENT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:864 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:864 ] .
 
 
 
-ABA:638 rdf:type owl:Class ;
+MBA:638 rdf:type owl:Class ;
 
         rdfs:label "Gustatory areas, layer 6a"@en ;
 
         nsu:synonym "GU6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:639 rdf:type owl:Class ;
+MBA:639 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, anterior part"@en ;
 
         nsu:synonym "COAa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:631 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:631 ] .
 
 
 
-ABA:64 rdf:type owl:Class ;
+MBA:64 rdf:type owl:Class ;
 
        rdfs:label "Anterodorsal nucleus"@en ;
 
        nsu:synonym "AD"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:239 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:239 ] .
 
 
 
-ABA:640 rdf:type owl:Class ;
+MBA:640 rdf:type owl:Class ;
 
         rdfs:label "Efferent vestibular nucleus"@en ;
 
         nsu:synonym "EV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:641 rdf:type owl:Class ;
+MBA:641 rdf:type owl:Class ;
 
         rdfs:label "intermediate acoustic stria"@en ;
 
         nsu:synonym "ias"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:642 rdf:type owl:Class ;
+MBA:642 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the trapezoid body"@en ;
 
         nsu:synonym "NTB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:643 rdf:type owl:Class ;
+MBA:643 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 2/3"@en ;
 
         nsu:synonym "AUDpo2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:644 rdf:type owl:Class ;
+MBA:644 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas, Layer 6a"@en ;
 
         nsu:synonym "MO6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:645 rdf:type owl:Class ;
+MBA:645 rdf:type owl:Class ;
 
         rdfs:label "Vermal regions"@en ;
 
         nsu:synonym "VERM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:528 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:528 ] .
 
 
 
-ABA:646 rdf:type owl:Class ;
+MBA:646 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area, layer 5"@en ;
 
         nsu:synonym "DP5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:814 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:814 ] .
 
 
 
-ABA:647 rdf:type owl:Class ;
+MBA:647 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part"@en ;
 
         nsu:synonym "COAp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:631 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:631 ] .
 
 
 
-ABA:648 rdf:type owl:Class ;
+MBA:648 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area, Layer 5"@en ;
 
         nsu:synonym "MOp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:985 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:985 ] .
 
 
 
-ABA:649 rdf:type owl:Class ;
+MBA:649 rdf:type owl:Class ;
 
         rdfs:label "Anterolateral visual area, layer 6b"@en ;
 
         nsu:synonym "VISal6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:65 rdf:type owl:Class ;
+MBA:65 rdf:type owl:Class ;
 
        rdfs:label "parafloccular sulcus"@en ;
 
        nsu:synonym "pfs"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1040 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1040 ] .
 
 
 
-ABA:650 rdf:type owl:Class ;
+MBA:650 rdf:type owl:Class ;
 
         rdfs:label "juxtarestiform body"@en ;
 
         nsu:synonym "jrb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1123 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1123 ] .
 
 
 
-ABA:651 rdf:type owl:Class ;
+MBA:651 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract"@en ;
 
         nsu:synonym "NTS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:652 rdf:type owl:Class ;
+MBA:652 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, lateral zone"@en ;
 
         nsu:synonym "PVHpml"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:103 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:103 ] .
 
 
 
-ABA:653 rdf:type owl:Class ;
+MBA:653 rdf:type owl:Class ;
 
         rdfs:label "Abducens nucleus"@en ;
 
         nsu:synonym "VI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:654 rdf:type owl:Class ;
+MBA:654 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 4"@en ;
 
         nsu:synonym "SSp-n4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:655 rdf:type owl:Class ;
+MBA:655 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, lateral zone"@en ;
 
         nsu:synonym "COApl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:647 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:647 ] .
 
 
 
-ABA:656 rdf:type owl:Class ;
+MBA:656 rdf:type owl:Class ;
 
         rdfs:label "Secondary motor area, layer 1"@en ;
 
         nsu:synonym "MOs1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:993 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:993 ] .
 
 
 
-ABA:657 rdf:type owl:Class ;
+MBA:657 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, mouth, layer 2/3"@en ;
 
         nsu:synonym "SSp-m2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:658 rdf:type owl:Class ;
+MBA:658 rdf:type owl:Class ;
 
         rdfs:label "lateral lemniscus"@en ;
 
         nsu:synonym "ll"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:659 rdf:type owl:Class ;
+MBA:659 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract, central part"@en ;
 
         nsu:synonym "NTSce"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:651 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:651 ] .
 
 
 
-ABA:66 rdf:type owl:Class ;
+MBA:66 rdf:type owl:Class ;
 
        rdfs:label "Lateral terminal nucleus of the accessory optic tract"@en ;
 
        nsu:synonym "LT"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:660 rdf:type owl:Class ;
+MBA:660 rdf:type owl:Class ;
 
         rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, medial zone"@en ;
 
         nsu:synonym "PVHpmm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:103 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:103 ] .
 
 
 
-ABA:661 rdf:type owl:Class ;
+MBA:661 rdf:type owl:Class ;
 
         rdfs:label "Facial motor nucleus"@en ;
 
         nsu:synonym "VII"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:662 rdf:type owl:Class ;
+MBA:662 rdf:type owl:Class ;
 
         rdfs:label "Gustatory areas, layer 6b"@en ;
 
         nsu:synonym "GU6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1057 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1057 ] .
 
 
 
-ABA:663 rdf:type owl:Class ;
+MBA:663 rdf:type owl:Class ;
 
         rdfs:label "Cortical amygdalar area, posterior part, medial zone"@en ;
 
         nsu:synonym "COApm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:647 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:647 ] .
 
 
 
-ABA:664 rdf:type owl:Class ;
+MBA:664 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 3"@en ;
 
         nsu:synonym "ENTm3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:665 rdf:type owl:Class ;
+MBA:665 rdf:type owl:Class ;
 
         rdfs:label "lateral olfactory tract, body"@en ;
 
         nsu:synonym "lot"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:21 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:21 ] .
 
 
 
-ABA:666 rdf:type owl:Class ;
+MBA:666 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract, commissural part"@en ;
 
         nsu:synonym "NTSco"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:651 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:651 ] .
 
 
 
-ABA:667 rdf:type owl:Class ;
+MBA:667 rdf:type owl:Class ;
 
         rdfs:label "Frontal pole, layer 2/3"@en ;
 
         nsu:synonym "FRP2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:184 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:184 ] .
 
 
 
-ABA:668 rdf:type owl:Class ;
+MBA:668 rdf:type owl:Class ;
 
         rdfs:label "Dorsomedial nucleus of the hypothalamus, anterior part"@en ;
 
         nsu:synonym "DMHa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:830 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:830 ] .
 
 
 
-ABA:669 rdf:type owl:Class ;
+MBA:669 rdf:type owl:Class ;
 
         rdfs:label "Visual areas"@en ;
 
         nsu:synonym "VIS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:67 rdf:type owl:Class ;
+MBA:67 rdf:type owl:Class ;
 
        rdfs:label "Interstitial nucleus of Cajal"@en ;
 
        nsu:synonym "INC"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:795 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:795 ] .
 
 
 
-ABA:670 rdf:type owl:Class ;
+MBA:670 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, trunk, layer 2/3"@en ;
 
         nsu:synonym "SSp-tr2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:671 rdf:type owl:Class ;
+MBA:671 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part, layer 1"@en ;
 
         nsu:synonym "RSPagl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:894 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:894 ] .
 
 
 
-ABA:672 rdf:type owl:Class ;
+MBA:672 rdf:type owl:Class ;
 
         rdfs:label "Caudoputamen"@en ;
 
         nsu:synonym "CP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:485 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:485 ] .
 
 
 
-ABA:673 rdf:type owl:Class ;
+MBA:673 rdf:type owl:Class ;
 
         rdfs:label "mammillary peduncle"@en ;
 
         nsu:synonym "mp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:46 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:46 ] .
 
 
 
-ABA:674 rdf:type owl:Class ;
+MBA:674 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract, gelatinous part"@en ;
 
         nsu:synonym "NTSge"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:651 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:651 ] .
 
 
 
-ABA:675 rdf:type owl:Class ;
+MBA:675 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part, layer 6a"@en ;
 
         nsu:synonym "AIv6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:119 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:119 ] .
 
 
 
-ABA:676 rdf:type owl:Class ;
+MBA:676 rdf:type owl:Class ;
 
         rdfs:label "Dorsomedial nucleus of the hypothalamus, posterior part"@en ;
 
         nsu:synonym "DMHp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:830 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:830 ] .
 
 
 
-ABA:677 rdf:type owl:Class ;
+MBA:677 rdf:type owl:Class ;
 
         rdfs:label "Visceral area"@en ;
 
         nsu:synonym "VISC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:678 rdf:type owl:Class ;
+MBA:678 rdf:type owl:Class ;
 
         rdfs:label "Dorsal auditory area, layer 4"@en ;
 
         nsu:synonym "AUDd4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1011 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1011 ] .
 
 
 
-ABA:679 rdf:type owl:Class ;
+MBA:679 rdf:type owl:Class ;
 
         rdfs:label "Superior central nucleus raphe"@en ;
 
         nsu:synonym "CS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1117 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1117 ] .
 
 
 
-ABA:68 rdf:type owl:Class ;
+MBA:68 rdf:type owl:Class ;
 
        rdfs:label "Frontal pole, layer 1"@en ;
 
        nsu:synonym "FRP1"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:184 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:184 ] .
 
 
 
-ABA:680 rdf:type owl:Class ;
+MBA:680 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventrolateral part, layer 6b"@en ;
 
         nsu:synonym "ORBvl6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:746 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:746 ] .
 
 
 
-ABA:681 rdf:type owl:Class ;
+MBA:681 rdf:type owl:Class ;
 
         rdfs:label "mammillotegmental tract"@en ;
 
         nsu:synonym "mtg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:46 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:46 ] .
 
 
 
-ABA:682 rdf:type owl:Class ;
+MBA:682 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract, lateral part"@en ;
 
         nsu:synonym "NTSl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:651 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:651 ] .
 
 
 
-ABA:683 rdf:type owl:Class ;
+MBA:683 rdf:type owl:Class ;
 
         rdfs:label "Posterior parietal association areas, layer 5"@en ;
 
         nsu:synonym "PTLp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:22 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:22 ] .
 
 
 
-ABA:684 rdf:type owl:Class ;
+MBA:684 rdf:type owl:Class ;
 
         rdfs:label "Dorsomedial nucleus of the hypothalamus, ventral part"@en ;
 
         nsu:synonym "DMHv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:830 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:830 ] .
 
 
 
-ABA:685 rdf:type owl:Class ;
+MBA:685 rdf:type owl:Class ;
 
         rdfs:label "Ventral medial nucleus of the thalamus"@en ;
 
         nsu:synonym "VM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:637 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:637 ] .
 
 
 
-ABA:686 rdf:type owl:Class ;
+MBA:686 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 6a"@en ;
 
         nsu:synonym "SSp6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:687 rdf:type owl:Class ;
+MBA:687 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part, layer 5"@en ;
 
         nsu:synonym "RSPv5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:886 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:886 ] .
 
 
 
-ABA:688 rdf:type owl:Class ;
+MBA:688 rdf:type owl:Class ;
 
         rdfs:label "Cerebral cortex"@en ;
 
         nsu:synonym "CTX"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:567 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:567 ] .
 
 
 
-ABA:689 rdf:type owl:Class ;
+MBA:689 rdf:type owl:Class ;
 
         rdfs:label "Ventrolateral preoptic nucleus"@en ;
 
         nsu:synonym "VLPO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:69 rdf:type owl:Class ;
+MBA:69 rdf:type owl:Class ;
 
        rdfs:label "Spinal nucleus of the trigeminal, oral part, ventrolateral part"@en ;
 
        nsu:synonym "SPVOvl"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:445 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:445 ] .
 
 
 
-ABA:690 rdf:type owl:Class ;
+MBA:690 rdf:type owl:Class ;
 
         rdfs:label "mammilothalmic tract"@en ;
 
         nsu:synonym "mtt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:46 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:46 ] .
 
 
 
-ABA:691 rdf:type owl:Class ;
+MBA:691 rdf:type owl:Class ;
 
         rdfs:label "Nucleus of the solitary tract, medial part"@en ;
 
         nsu:synonym "NTSm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:651 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:651 ] .
 
 
 
-ABA:692 rdf:type owl:Class ;
+MBA:692 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area, layer 5"@en ;
 
         nsu:synonym "PERI5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:922 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:922 ] .
 
 
 
-ABA:693 rdf:type owl:Class ;
+MBA:693 rdf:type owl:Class ;
 
         rdfs:label "Ventromedial hypothalamic nucleus"@en ;
 
         nsu:synonym "VMH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:694 rdf:type owl:Class ;
+MBA:694 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part, layer 2/3"@en ;
 
         nsu:synonym "AIv2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:119 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:119 ] .
 
 
 
-ABA:695 rdf:type owl:Class ;
+MBA:695 rdf:type owl:Class ;
 
         rdfs:label "Cortical plate"@en ;
 
         nsu:synonym "CTXpl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:688 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:688 ] .
 
 
 
-ABA:696 rdf:type owl:Class ;
+MBA:696 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 1"@en ;
 
         nsu:synonym "AUDpo1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:697 rdf:type owl:Class ;
+MBA:697 rdf:type owl:Class ;
 
         rdfs:label "medial lemniscus"@en ;
 
         nsu:synonym "ml"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:698 rdf:type owl:Class ;
+MBA:698 rdf:type owl:Class ;
 
         rdfs:label "Olfactory areas"@en ;
 
         nsu:synonym "OLF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:695 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:695 ] .
 
 
 
-ABA:699 rdf:type owl:Class ;
+MBA:699 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part, layer 6b"@en ;
 
         nsu:synonym "AIv6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:119 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:119 ] .
 
 
 
-ABA:7 rdf:type owl:Class ;
+MBA:7 rdf:type owl:Class ;
 
       rdfs:label "Principal sensory nucleus of the trigeminal"@en ;
 
       nsu:synonym "PSV"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1132 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1132 ] .
 
 
 
-ABA:70 rdf:type owl:Class ;
+MBA:70 rdf:type owl:Class ;
 
        rdfs:label "midbrain related"@en ;
 
        nsu:synonym "mfbsm"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:824 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:824 ] .
 
 
 
-ABA:700 rdf:type owl:Class ;
+MBA:700 rdf:type owl:Class ;
 
         rdfs:label "Anterior hypothalamic nucleus, anterior part"@en ;
 
         nsu:synonym "AHNa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:88 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:88 ] .
 
 
 
-ABA:701 rdf:type owl:Class ;
+MBA:701 rdf:type owl:Class ;
 
         rdfs:label "Vestibular nuclei"@en ;
 
         nsu:synonym "VNC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:702 rdf:type owl:Class ;
+MBA:702 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 5"@en ;
 
         nsu:synonym "SSp-n5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:703 rdf:type owl:Class ;
+MBA:703 rdf:type owl:Class ;
 
         rdfs:label "Cortical subplate"@en ;
 
         nsu:synonym "CTXsp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:688 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:688 ] .
 
 
 
-ABA:704 rdf:type owl:Class ;
+MBA:704 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part, layer 1"@en ;
 
         nsu:synonym "AIv1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:119 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:119 ] .
 
 
 
-ABA:705 rdf:type owl:Class ;
+MBA:705 rdf:type owl:Class ;
 
         rdfs:label "midbrain tract of the trigeminal nerve"@en ;
 
         nsu:synonym "mtV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:229 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:229 ] .
 
 
 
-ABA:706 rdf:type owl:Class ;
+MBA:706 rdf:type owl:Class ;
 
         rdfs:label "Olivary pretectal nucleus"@en ;
 
         nsu:synonym "OP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1100 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1100 ] .
 
 
 
-ABA:707 rdf:type owl:Class ;
+MBA:707 rdf:type owl:Class ;
 
         rdfs:label "Infralimbic area, layer 1"@en ;
 
         nsu:synonym "ILA1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:708 rdf:type owl:Class ;
+MBA:708 rdf:type owl:Class ;
 
         rdfs:label "Anterior hypothalamic nucleus, central part"@en ;
 
         nsu:synonym "AHNc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:88 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:88 ] .
 
 
 
-ABA:709 rdf:type owl:Class ;
+MBA:709 rdf:type owl:Class ;
 
         rdfs:label "Ventral posterior complex of the thalamus"@en ;
 
         nsu:synonym "VP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:637 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:637 ] .
 
 
 
-ABA:71 rdf:type owl:Class ;
+MBA:71 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division"@en ;
 
        nsu:synonym "PVHm"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:38 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:38 ] .
 
 
 
-ABA:710 rdf:type owl:Class ;
+MBA:710 rdf:type owl:Class ;
 
         rdfs:label "abducens nerve"@en ;
 
         nsu:synonym "VIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:711 rdf:type owl:Class ;
+MBA:711 rdf:type owl:Class ;
 
         rdfs:label "Cuneate nucleus"@en ;
 
         nsu:synonym "CU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:720 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:720 ] .
 
 
 
-ABA:712 rdf:type owl:Class ;
+MBA:712 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 4"@en ;
 
         nsu:synonym "ENTm4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:713 rdf:type owl:Class ;
+MBA:713 rdf:type owl:Class ;
 
         rdfs:label "perforant path"@en ;
 
         nsu:synonym "per"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:714 rdf:type owl:Class ;
+MBA:714 rdf:type owl:Class ;
 
         rdfs:label "Orbital area"@en ;
 
         nsu:synonym "ORB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:715 rdf:type owl:Class ;
+MBA:715 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 2a"@en ;
 
         nsu:synonym "ENTl2a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:716 rdf:type owl:Class ;
+MBA:716 rdf:type owl:Class ;
 
         rdfs:label "Anterior hypothalamic nucleus, dorsal part"@en ;
 
         nsu:synonym "AHNd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:88 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:88 ] .
 
 
 
-ABA:717 rdf:type owl:Class ;
+MBA:717 rdf:type owl:Class ;
 
         rdfs:label "accessory spinal nerve"@en ;
 
         nsu:synonym "XIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:718 rdf:type owl:Class ;
+MBA:718 rdf:type owl:Class ;
 
         rdfs:label "Ventral posterolateral nucleus of the thalamus"@en ;
 
         nsu:synonym "VPL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:709 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:709 ] .
 
 
 
-ABA:719 rdf:type owl:Class ;
+MBA:719 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 6b"@en ;
 
         nsu:synonym "SSp6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:72 rdf:type owl:Class ;
+MBA:72 rdf:type owl:Class ;
 
        rdfs:label "Anterodorsal preoptic nucleus"@en ;
 
        nsu:synonym "ADP"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:720 rdf:type owl:Class ;
+MBA:720 rdf:type owl:Class ;
 
         rdfs:label "Dorsal column nuclei"@en ;
 
         nsu:synonym "DCN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:721 rdf:type owl:Class ;
+MBA:721 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area, layer 4"@en ;
 
         nsu:synonym "VISp4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:722 rdf:type owl:Class ;
+MBA:722 rdf:type owl:Class ;
 
         rdfs:label "periventricular bundle of the thalamus"@en ;
 
         nsu:synonym "pvbt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1068 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1068 ] .
 
 
 
-ABA:723 rdf:type owl:Class ;
+MBA:723 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, lateral part"@en ;
 
         nsu:synonym "ORBl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:724 rdf:type owl:Class ;
+MBA:724 rdf:type owl:Class ;
 
         rdfs:label "Anterior hypothalamic nucleus, posterior part"@en ;
 
         nsu:synonym "AHNp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:88 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:88 ] .
 
 
 
-ABA:725 rdf:type owl:Class ;
+MBA:725 rdf:type owl:Class ;
 
         rdfs:label "Ventral posterolateral nucleus of the thalamus, parvicellular part"@en ;
 
         nsu:synonym "VPLpc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:709 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:709 ] .
 
 
 
-ABA:726 rdf:type owl:Class ;
+MBA:726 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus"@en ;
 
         nsu:synonym "DG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1080 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1080 ] .
 
 
 
-ABA:727 rdf:type owl:Class ;
+MBA:727 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 5"@en ;
 
         nsu:synonym "ENTm5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:728 rdf:type owl:Class ;
+MBA:728 rdf:type owl:Class ;
 
         rdfs:label "arbor vitae"@en ;
 
         nsu:synonym "arb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:960 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:960 ] .
 
 
 
-ABA:729 rdf:type owl:Class ;
+MBA:729 rdf:type owl:Class ;
 
         rdfs:label "Temporal association areas, layer 6a"@en ;
 
         nsu:synonym "TEa6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:73 rdf:type owl:Class ;
+MBA:73 rdf:type owl:Class ;
 
        rdfs:label "ventricular systems"@en ;
 
        nsu:synonym "VS"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:997 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:997 ] .
 
 
 
-ABA:730 rdf:type owl:Class ;
+MBA:730 rdf:type owl:Class ;
 
         rdfs:label "pineal stalk"@en ;
 
         nsu:synonym "PIS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1083 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1083 ] .
 
 
 
-ABA:731 rdf:type owl:Class ;
+MBA:731 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part"@en ;
 
         nsu:synonym "ORBm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:732 rdf:type owl:Class ;
+MBA:732 rdf:type owl:Class ;
 
         rdfs:label "Medial mammillary nucleus, median part"@en ;
 
         nsu:synonym "Mmme"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:491 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:491 ] .
 
 
 
-ABA:733 rdf:type owl:Class ;
+MBA:733 rdf:type owl:Class ;
 
         rdfs:label "Ventral posteromedial nucleus of the thalamus"@en ;
 
         nsu:synonym "VPM"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:709 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:709 ] .
 
 
 
-ABA:734 rdf:type owl:Class ;
+MBA:734 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus crest"@en ;
 
         nsu:synonym "DGcr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:735 rdf:type owl:Class ;
+MBA:735 rdf:type owl:Class ;
 
         rdfs:label "Primary auditory area, layer 1"@en ;
 
         nsu:synonym "AUDp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:736 rdf:type owl:Class ;
+MBA:736 rdf:type owl:Class ;
 
         rdfs:label "central tegmental bundle"@en ;
 
         nsu:synonym "ctb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:737 rdf:type owl:Class ;
+MBA:737 rdf:type owl:Class ;
 
         rdfs:label "postcommissural fornix"@en ;
 
         nsu:synonym "fxpo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:738 rdf:type owl:Class ;
+MBA:738 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventral part"@en ;
 
         nsu:synonym "ORBv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:739 rdf:type owl:Class ;
+MBA:739 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, layer 5"@en ;
 
         nsu:synonym "ACA5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:31 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:31 ] .
 
 
 
-ABA:74 rdf:type owl:Class ;
+MBA:74 rdf:type owl:Class ;
 
        rdfs:label "Lateral visual area, layer 6a"@en ;
 
        nsu:synonym "VISl6a"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:740 rdf:type owl:Class ;
+MBA:740 rdf:type owl:Class ;
 
         rdfs:label "Medial preoptic nucleus, central part"@en ;
 
         nsu:synonym "MPNc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:515 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:515 ] .
 
 
 
-ABA:741 rdf:type owl:Class ;
+MBA:741 rdf:type owl:Class ;
 
         rdfs:label "Ventral posteromedial nucleus of the thalamus, parvicellular part"@en ;
 
         nsu:synonym "VPMpc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:709 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:709 ] .
 
 
 
-ABA:742 rdf:type owl:Class ;
+MBA:742 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus crest, molecular layer"@en ;
 
         nsu:synonym "DGcr-mo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:734 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:734 ] .
 
 
 
-ABA:743 rdf:type owl:Class ;
+MBA:743 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone, layer 6"@en ;
 
         nsu:synonym "ENTm6"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:926 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:926 ] .
 
 
 
-ABA:744 rdf:type owl:Class ;
+MBA:744 rdf:type owl:Class ;
 
         rdfs:label "cerebellar commissure"@en ;
 
         nsu:synonym "cbc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:960 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:960 ] .
 
 
 
-ABA:745 rdf:type owl:Class ;
+MBA:745 rdf:type owl:Class ;
 
         rdfs:label "precommissural fornix, general"@en ;
 
         nsu:synonym "fxprg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1099 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1099 ] .
 
 
 
-ABA:746 rdf:type owl:Class ;
+MBA:746 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventrolateral part"@en ;
 
         nsu:synonym "ORBvl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:714 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:714 ] .
 
 
 
-ABA:747 rdf:type owl:Class ;
+MBA:747 rdf:type owl:Class ;
 
         rdfs:label "Infralimbic area, layer 2"@en ;
 
         nsu:synonym "ILA2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:748 rdf:type owl:Class ;
+MBA:748 rdf:type owl:Class ;
 
         rdfs:label "Medial preoptic nucleus, lateral part"@en ;
 
         nsu:synonym "MPNl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:515 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:515 ] .
 
 
 
-ABA:749 rdf:type owl:Class ;
+MBA:749 rdf:type owl:Class ;
 
         rdfs:label "Ventral tegmental area"@en ;
 
         nsu:synonym "VTA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:75 rdf:type owl:Class ;
+MBA:75 rdf:type owl:Class ;
 
        rdfs:label "Dorsal terminal nucleus of the accessory optic tract"@en ;
 
        nsu:synonym "DT"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:750 rdf:type owl:Class ;
+MBA:750 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 1"@en ;
 
         nsu:synonym "VISpl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:751 rdf:type owl:Class ;
+MBA:751 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus crest, polymorph layer"@en ;
 
         nsu:synonym "DGcr-po"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:734 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:734 ] .
 
 
 
-ABA:752 rdf:type owl:Class ;
+MBA:752 rdf:type owl:Class ;
 
         rdfs:label "cerebellar peduncles"@en ;
 
         nsu:synonym "cbp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:960 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:960 ] .
 
 
 
-ABA:753 rdf:type owl:Class ;
+MBA:753 rdf:type owl:Class ;
 
         rdfs:label "principal mammillary tract"@en ;
 
         nsu:synonym "pm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:46 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:46 ] .
 
 
 
-ABA:754 rdf:type owl:Class ;
+MBA:754 rdf:type owl:Class ;
 
         rdfs:label "Olfactory tubercle"@en ;
 
         nsu:synonym "OT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:493 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:493 ] .
 
 
 
-ABA:755 rdf:type owl:Class ;
+MBA:755 rdf:type owl:Class ;
 
         rdfs:label "Ventral auditory area, layer 2/3"@en ;
 
         nsu:synonym "AUDv2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:756 rdf:type owl:Class ;
+MBA:756 rdf:type owl:Class ;
 
         rdfs:label "Medial preoptic nucleus, medial part"@en ;
 
         nsu:synonym "MPNm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:515 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:515 ] .
 
 
 
-ABA:757 rdf:type owl:Class ;
+MBA:757 rdf:type owl:Class ;
 
         rdfs:label "Ventral tegmental nucleus"@en ;
 
         nsu:synonym "VTN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:758 rdf:type owl:Class ;
+MBA:758 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus crest, granule cell layer"@en ;
 
         nsu:synonym "DGcr-sg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:734 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:734 ] .
 
 
 
-ABA:759 rdf:type owl:Class ;
+MBA:759 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 4"@en ;
 
         nsu:synonym "AUDpo4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:76 rdf:type owl:Class ;
+MBA:76 rdf:type owl:Class ;
 
        rdfs:label "Interstitial nucleus of the vestibular nerve"@en ;
 
        nsu:synonym "INV"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:760 rdf:type owl:Class ;
+MBA:760 rdf:type owl:Class ;
 
         rdfs:label "cerebral nuclei related"@en ;
 
         nsu:synonym "epsc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:761 rdf:type owl:Class ;
+MBA:761 rdf:type owl:Class ;
 
         rdfs:label "Ventromedial hypothalamic nucleus, anterior part"@en ;
 
         nsu:synonym "VMHa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:693 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:693 ] .
 
 
 
-ABA:762 rdf:type owl:Class ;
+MBA:762 rdf:type owl:Class ;
 
         rdfs:label "propriohypothalamic pathways, dorsal"@en ;
 
         nsu:synonym "phpd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182 ] .
 
 
 
-ABA:763 rdf:type owl:Class ;
+MBA:763 rdf:type owl:Class ;
 
         rdfs:label "Vascular organ of the lamina terminalis"@en ;
 
         nsu:synonym "OV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:764 rdf:type owl:Class ;
+MBA:764 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 2b"@en ;
 
         nsu:synonym "ENTl2b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:765 rdf:type owl:Class ;
+MBA:765 rdf:type owl:Class ;
 
         rdfs:label "Nucleus x"@en ;
 
         nsu:synonym "x"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:766 rdf:type owl:Class ;
+MBA:766 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus lateral blade"@en ;
 
         nsu:synonym "DGlb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:767 rdf:type owl:Class ;
+MBA:767 rdf:type owl:Class ;
 
         rdfs:label "Secondary motor area, layer 5"@en ;
 
         nsu:synonym "MOs5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:993 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:993 ] .
 
 
 
-ABA:768 rdf:type owl:Class ;
+MBA:768 rdf:type owl:Class ;
 
         rdfs:label "cerebrum related"@en ;
 
         nsu:synonym "mfbc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:991 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:991 ] .
 
 
 
-ABA:769 rdf:type owl:Class ;
+MBA:769 rdf:type owl:Class ;
 
         rdfs:label "Ventromedial hypothalamic nucleus, central part"@en ;
 
         nsu:synonym "VMHc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:693 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:693 ] .
 
 
 
-ABA:77 rdf:type owl:Class ;
+MBA:77 rdf:type owl:Class ;
 
        rdfs:label "Spinal nucleus of the trigeminal, oral part, caudal dorsomedial part"@en ;
 
        nsu:synonym "SPVOcdm"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:445 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:445 ] .
 
 
 
-ABA:770 rdf:type owl:Class ;
+MBA:770 rdf:type owl:Class ;
 
         rdfs:label "propriohypothalamic pathways, lateral"@en ;
 
         nsu:synonym "phpl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182 ] .
 
 
 
-ABA:771 rdf:type owl:Class ;
+MBA:771 rdf:type owl:Class ;
 
         rdfs:label "Pons"@en ;
 
         nsu:synonym "P"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1065 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1065 ] .
 
 
 
-ABA:772 rdf:type owl:Class ;
+MBA:772 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, ventral part, layer 5"@en ;
 
         nsu:synonym "ACAv5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:48 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:48 ] .
 
 
 
-ABA:773 rdf:type owl:Class ;
+MBA:773 rdf:type owl:Class ;
 
         rdfs:label "Hypoglossal nucleus"@en ;
 
         nsu:synonym "XII"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:774 rdf:type owl:Class ;
+MBA:774 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part, layer 5"@en ;
 
         nsu:synonym "RSPagl5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:894 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:894 ] .
 
 
 
-ABA:775 rdf:type owl:Class ;
+MBA:775 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus lateral blade, molecular layer"@en ;
 
         nsu:synonym "DGlb-mo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:766 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:766 ] .
 
 
 
-ABA:776 rdf:type owl:Class ;
+MBA:776 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum"@en ;
 
         nsu:synonym "cc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:983 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:983 ] .
 
 
 
-ABA:777 rdf:type owl:Class ;
+MBA:777 rdf:type owl:Class ;
 
         rdfs:label "Ventromedial hypothalamic nucleus, dorsomedial part"@en ;
 
         nsu:synonym "VMHdm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:693 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:693 ] .
 
 
 
-ABA:778 rdf:type owl:Class ;
+MBA:778 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area, layer 5"@en ;
 
         nsu:synonym "VISp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:779 rdf:type owl:Class ;
+MBA:779 rdf:type owl:Class ;
 
         rdfs:label "propriohypothalamic pathways, medial"@en ;
 
         nsu:synonym "phpm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182 ] .
 
 
 
-ABA:78 rdf:type owl:Class ;
+MBA:78 rdf:type owl:Class ;
 
        rdfs:label "middle cerebellar peduncle"@en ;
 
        nsu:synonym "mcp"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:752 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:752 ] .
 
 
 
-ABA:780 rdf:type owl:Class ;
+MBA:780 rdf:type owl:Class ;
 
         rdfs:label "Posterior amygdalar nucleus"@en ;
 
         nsu:synonym "PA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:781 rdf:type owl:Class ;
+MBA:781 rdf:type owl:Class ;
 
         rdfs:label "Nucleus y"@en ;
 
         nsu:synonym "y"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:782 rdf:type owl:Class ;
+MBA:782 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus lateral blade, polymorph layer"@en ;
 
         nsu:synonym "DGlb-po"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:766 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:766 ] .
 
 
 
-ABA:783 rdf:type owl:Class ;
+MBA:783 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, dorsal part, layer 6a"@en ;
 
         nsu:synonym "AId6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:104 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:104 ] .
 
 
 
-ABA:784 rdf:type owl:Class ;
+MBA:784 rdf:type owl:Class ;
 
         rdfs:label "corticospinal tract"@en ;
 
         nsu:synonym "cst"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:983 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:983 ] .
 
 
 
-ABA:785 rdf:type owl:Class ;
+MBA:785 rdf:type owl:Class ;
 
         rdfs:label "Ventromedial hypothalamic nucleus, ventrolateral part"@en ;
 
         nsu:synonym "VMHvl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:693 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:693 ] .
 
 
 
-ABA:786 rdf:type owl:Class ;
+MBA:786 rdf:type owl:Class ;
 
         rdfs:label "Temporal association areas, layer 6b"@en ;
 
         nsu:synonym "TEa6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:787 rdf:type owl:Class ;
+MBA:787 rdf:type owl:Class ;
 
         rdfs:label "propriohypothalamic pathways, ventral"@en ;
 
         nsu:synonym "phpv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:182 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:182 ] .
 
 
 
-ABA:788 rdf:type owl:Class ;
+MBA:788 rdf:type owl:Class ;
 
         rdfs:label "Piriform-amygdalar area"@en ;
 
         nsu:synonym "PAA"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:789 rdf:type owl:Class ;
+MBA:789 rdf:type owl:Class ;
 
         rdfs:label "Nucleus z"@en ;
 
         nsu:synonym "z"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:79 rdf:type owl:Class ;
+MBA:79 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, magnocellular division, medial magnocellular part"@en ;
 
        nsu:synonym "PVHmm"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:71 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:71 ] .
 
 
 
-ABA:790 rdf:type owl:Class ;
+MBA:790 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus lateral blade, granule cell layer"@en ;
 
         nsu:synonym "DGlb-sg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:766 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:766 ] .
 
 
 
-ABA:791 rdf:type owl:Class ;
+MBA:791 rdf:type owl:Class ;
 
         rdfs:label "Posterior auditory area, layer 5"@en ;
 
         nsu:synonym "AUDpo5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1027 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1027 ] .
 
 
 
-ABA:792 rdf:type owl:Class ;
+MBA:792 rdf:type owl:Class ;
 
         rdfs:label "dorsal roots"@en ;
 
         nsu:synonym "drt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:793 rdf:type owl:Class ;
+MBA:793 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 1"@en ;
 
         nsu:synonym "SSp1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:794 rdf:type owl:Class ;
+MBA:794 rdf:type owl:Class ;
 
         rdfs:label "spinal tract of the trigeminal nerve"@en ;
 
         nsu:synonym "sptV"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:229 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:229 ] .
 
 
 
-ABA:795 rdf:type owl:Class ;
+MBA:795 rdf:type owl:Class ;
 
         rdfs:label "Periaqueductal gray"@en ;
 
         nsu:synonym "PAG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:796 rdf:type owl:Class ;
+MBA:796 rdf:type owl:Class ;
 
         rdfs:label "Dopaminergic A13 group"@en ;
 
         nsu:synonym "A13"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:797 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:797 ] .
 
 
 
-ABA:797 rdf:type owl:Class ;
+MBA:797 rdf:type owl:Class ;
 
         rdfs:label "Zona incerta"@en ;
 
         nsu:synonym "ZI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:290 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:290 ] .
 
 
 
-ABA:798 rdf:type owl:Class ;
+MBA:798 rdf:type owl:Class ;
 
         rdfs:label "facial nerve"@en ;
 
         nsu:synonym "VIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:799 rdf:type owl:Class ;
+MBA:799 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus medial blade"@en ;
 
         nsu:synonym "DGmb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:726 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:726 ] .
 
 
 
-ABA:8 rdf:type owl:Class ;
+MBA:8 rdf:type owl:Class ;
 
       rdfs:label "Basic cell groups and regions"@en ;
 
       nsu:synonym "grey"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:997 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:997 ] .
 
 
 
-ABA:80 rdf:type owl:Class ;
+MBA:80 rdf:type owl:Class ;
 
        rdfs:label "Anterior hypothalamic area"@en ;
 
        nsu:synonym "AHA"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:800 rdf:type owl:Class ;
+MBA:800 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, ventral part, layer 5"@en ;
 
         nsu:synonym "AIv5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:119 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:119 ] .
 
 
 
-ABA:801 rdf:type owl:Class ;
+MBA:801 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 1"@en ;
 
         nsu:synonym "VIS1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:802 rdf:type owl:Class ;
+MBA:802 rdf:type owl:Class ;
 
         rdfs:label "stria medullaris"@en ;
 
         nsu:synonym "sm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1083 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1083 ] .
 
 
 
-ABA:803 rdf:type owl:Class ;
+MBA:803 rdf:type owl:Class ;
 
         rdfs:label "Pallidum"@en ;
 
         nsu:synonym "PAL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:623 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:623 ] .
 
 
 
-ABA:804 rdf:type owl:Class ;
+MBA:804 rdf:type owl:Class ;
 
         rdfs:label "Fields of Forel"@en ;
 
         nsu:synonym "FF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:797 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:797 ] .
 
 
 
-ABA:805 rdf:type owl:Class ;
+MBA:805 rdf:type owl:Class ;
 
         rdfs:label "posteromedial visual area, layer 1"@en ;
 
         nsu:synonym "VISpm1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:533 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:533 ] .
 
 
 
-ABA:806 rdf:type owl:Class ;
+MBA:806 rdf:type owl:Class ;
 
         rdfs:label "Supplemental somatosensory area, layer 2/3"@en ;
 
         nsu:synonym "SSs2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:807 rdf:type owl:Class ;
+MBA:807 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus medial blade, molecular layer"@en ;
 
         nsu:synonym "DGmb-mo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:799 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:799 ] .
 
 
 
-ABA:808 rdf:type owl:Class ;
+MBA:808 rdf:type owl:Class ;
 
         rdfs:label "glossopharyngeal nerve"@en ;
 
         nsu:synonym "IXn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:809 rdf:type owl:Class ;
+MBA:809 rdf:type owl:Class ;
 
         rdfs:label "Pallidum, caudal region"@en ;
 
         nsu:synonym "PALc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:803 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:803 ] .
 
 
 
-ABA:81 rdf:type owl:Class ;
+MBA:81 rdf:type owl:Class ;
 
        rdfs:label "lateral ventricle"@en ;
 
        nsu:synonym "VL"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:73 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:73 ] .
 
 
 
-ABA:810 rdf:type owl:Class ;
+MBA:810 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, ventral part, 6a"@en ;
 
         nsu:synonym "ACAv6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:48 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:48 ] .
 
 
 
-ABA:811 rdf:type owl:Class ;
+MBA:811 rdf:type owl:Class ;
 
         rdfs:label "Inferior colliculus, central nucleus"@en ;
 
         nsu:synonym "ICc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:4 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:4 ] .
 
 
 
-ABA:812 rdf:type owl:Class ;
+MBA:812 rdf:type owl:Class ;
 
         rdfs:label "superior cerebellar peduncle decussation"@en ;
 
         nsu:synonym "dscp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:326 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:326 ] .
 
 
 
-ABA:813 rdf:type owl:Class ;
+MBA:813 rdf:type owl:Class ;
 
         rdfs:label "hypoglossal nerve"@en ;
 
         nsu:synonym "XIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:814 rdf:type owl:Class ;
+MBA:814 rdf:type owl:Class ;
 
         rdfs:label "Dorsal peduncular area"@en ;
 
         nsu:synonym "DP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:815 rdf:type owl:Class ;
+MBA:815 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus medial blade, polymorph layer"@en ;
 
         nsu:synonym "DGmb-po"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:799 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:799 ] .
 
 
 
-ABA:816 rdf:type owl:Class ;
+MBA:816 rdf:type owl:Class ;
 
         rdfs:label "Primary auditory area, layer 4"@en ;
 
         nsu:synonym "AUDp4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:817 rdf:type owl:Class ;
+MBA:817 rdf:type owl:Class ;
 
         rdfs:label "supraoptic commissures, anterior"@en ;
 
         nsu:synonym "supa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:349 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:349 ] .
 
 
 
-ABA:818 rdf:type owl:Class ;
+MBA:818 rdf:type owl:Class ;
 
         rdfs:label "Pallidum, dorsal region"@en ;
 
         nsu:synonym "PALd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:803 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:803 ] .
 
 
 
-ABA:819 rdf:type owl:Class ;
+MBA:819 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, ventral part, 6b"@en ;
 
         nsu:synonym "ACAv6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:48 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:48 ] .
 
 
 
-ABA:82 rdf:type owl:Class ;
+MBA:82 rdf:type owl:Class ;
 
        rdfs:label "Nucleus of the lateral lemniscus, dorsal part"@en ;
 
        nsu:synonym "NLLd"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:612 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:612 ] .
 
 
 
-ABA:820 rdf:type owl:Class ;
+MBA:820 rdf:type owl:Class ;
 
         rdfs:label "Inferior colliculus, dorsal nucleus"@en ;
 
         nsu:synonym "ICd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:4 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:4 ] .
 
 
 
-ABA:821 rdf:type owl:Class ;
+MBA:821 rdf:type owl:Class ;
 
         rdfs:label "Primary visual area, layer 2/3"@en ;
 
         nsu:synonym "VISp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:385 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:385 ] .
 
 
 
-ABA:822 rdf:type owl:Class ;
+MBA:822 rdf:type owl:Class ;
 
         rdfs:label "Retrohippocampal region"@en ;
 
         nsu:synonym "RHP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1089 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1089 ] .
 
 
 
-ABA:823 rdf:type owl:Class ;
+MBA:823 rdf:type owl:Class ;
 
         rdfs:label "Dentate gyrus medial blade, granule cell layer"@en ;
 
         nsu:synonym "DGmb-sg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:799 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:799 ] .
 
 
 
-ABA:824 rdf:type owl:Class ;
+MBA:824 rdf:type owl:Class ;
 
         rdfs:label "hypothalamus related"@en ;
 
         nsu:synonym "mfsbshy"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:991 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:991 ] .
 
 
 
-ABA:825 rdf:type owl:Class ;
+MBA:825 rdf:type owl:Class ;
 
         rdfs:label "supraoptic commissures, dorsal"@en ;
 
         nsu:synonym "supd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:349 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:349 ] .
 
 
 
-ABA:826 rdf:type owl:Class ;
+MBA:826 rdf:type owl:Class ;
 
         rdfs:label "Pallidum, medial region"@en ;
 
         nsu:synonym "PALm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:803 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:803 ] .
 
 
 
-ABA:827 rdf:type owl:Class ;
+MBA:827 rdf:type owl:Class ;
 
         rdfs:label "Infralimbic area, layer 5"@en ;
 
         nsu:synonym "ILA5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:44 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:44 ] .
 
 
 
-ABA:828 rdf:type owl:Class ;
+MBA:828 rdf:type owl:Class ;
 
         rdfs:label "Inferior colliculus, external nucleus"@en ;
 
         nsu:synonym "ICe"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:4 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:4 ] .
 
 
 
-ABA:829 rdf:type owl:Class ;
+MBA:829 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, dorsal part, molecular layer"@en ;
 
         nsu:synonym "SUBd-m"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:509 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:509 ] .
 
 
 
-ABA:83 rdf:type owl:Class ;
+MBA:83 rdf:type owl:Class ;
 
        rdfs:label "Inferior olivary complex"@en ;
 
        nsu:synonym "IO"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:830 rdf:type owl:Class ;
+MBA:830 rdf:type owl:Class ;
 
         rdfs:label "Dorsomedial nucleus of the hypothalamus"@en ;
 
         nsu:synonym "DMH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:831 rdf:type owl:Class ;
+MBA:831 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, dorsal part, layer 6b"@en ;
 
         nsu:synonym "AId6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:104 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:104 ] .
 
 
 
-ABA:832 rdf:type owl:Class ;
+MBA:832 rdf:type owl:Class ;
 
         rdfs:label "oculomotor nerve"@en ;
 
         nsu:synonym "IIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:833 rdf:type owl:Class ;
+MBA:833 rdf:type owl:Class ;
 
         rdfs:label "supraoptic commissures, ventral"@en ;
 
         nsu:synonym "supv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:349 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:349 ] .
 
 
 
-ABA:834 rdf:type owl:Class ;
+MBA:834 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, zonal layer"@en ;
 
         nsu:synonym "SCzo"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:302 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:302 ] .
 
 
 
-ABA:835 rdf:type owl:Class ;
+MBA:835 rdf:type owl:Class ;
 
         rdfs:label "Pallidum, ventral region"@en ;
 
         nsu:synonym "PALv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:803 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:803 ] .
 
 
 
-ABA:836 rdf:type owl:Class ;
+MBA:836 rdf:type owl:Class ;
 
         rdfs:label "Ectorhinal area/Layer 1"@en ;
 
         nsu:synonym "ECT1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:895 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:895 ] .
 
 
 
-ABA:837 rdf:type owl:Class ;
+MBA:837 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, dorsal part, stratum radiatum"@en ;
 
         nsu:synonym "SUBd-sr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:509 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:509 ] .
 
 
 
-ABA:838 rdf:type owl:Class ;
+MBA:838 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 2/3"@en ;
 
         nsu:synonym "SSp-n2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:839 rdf:type owl:Class ;
+MBA:839 rdf:type owl:Class ;
 
         rdfs:label "Dorsal motor nucleus of the vagus nerve"@en ;
 
         nsu:synonym "DMX"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:84 rdf:type owl:Class ;
+MBA:84 rdf:type owl:Class ;
 
        rdfs:label "Prelimbic area, layer 6a"@en ;
 
        nsu:synonym "PL6a"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:972 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:972 ] .
 
 
 
-ABA:840 rdf:type owl:Class ;
+MBA:840 rdf:type owl:Class ;
 
         rdfs:label "olfactory nerve"@en ;
 
         nsu:synonym "In"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:841 rdf:type owl:Class ;
+MBA:841 rdf:type owl:Class ;
 
         rdfs:label "trapezoid body"@en ;
 
         nsu:synonym "tb"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:948 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:948 ] .
 
 
 
-ABA:842 rdf:type owl:Class ;
+MBA:842 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, superficial gray layer"@en ;
 
         nsu:synonym "SCsg"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:302 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:302 ] .
 
 
 
-ABA:843 rdf:type owl:Class ;
+MBA:843 rdf:type owl:Class ;
 
         rdfs:label "Parasubiculum"@en ;
 
         nsu:synonym "PAR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:822 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:822 ] .
 
 
 
-ABA:844 rdf:type owl:Class ;
+MBA:844 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area, Layer 6a"@en ;
 
         nsu:synonym "MOp6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:985 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:985 ] .
 
 
 
-ABA:845 rdf:type owl:Class ;
+MBA:845 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, dorsal part, pyramidal layer"@en ;
 
         nsu:synonym "SUBd-sp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:509 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:509 ] .
 
 
 
-ABA:846 rdf:type owl:Class ;
+MBA:846 rdf:type owl:Class ;
 
         rdfs:label "Dentate nucleus"@en ;
 
         nsu:synonym "DN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:519 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:519 ] .
 
 
 
-ABA:847 rdf:type owl:Class ;
+MBA:847 rdf:type owl:Class ;
 
         rdfs:label "Primary auditory area, layer 5"@en ;
 
         nsu:synonym "AUDp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:848 rdf:type owl:Class ;
+MBA:848 rdf:type owl:Class ;
 
         rdfs:label "optic nerve"@en ;
 
         nsu:synonym "IIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:849 rdf:type owl:Class ;
+MBA:849 rdf:type owl:Class ;
 
         rdfs:label "Visceral area, layer 6b"@en ;
 
         nsu:synonym "VISC6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:85 rdf:type owl:Class ;
+MBA:85 rdf:type owl:Class ;
 
        rdfs:label "spinocerebellar tract"@en ;
 
        nsu:synonym "sct"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:812 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:812 ] .
 
 
 
-ABA:850 rdf:type owl:Class ;
+MBA:850 rdf:type owl:Class ;
 
         rdfs:label "uncinate fascicle"@en ;
 
         nsu:synonym "uf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:326 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:326 ] .
 
 
 
-ABA:851 rdf:type owl:Class ;
+MBA:851 rdf:type owl:Class ;
 
         rdfs:label "Superior colliculus, optic layer"@en ;
 
         nsu:synonym "SCop"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:302 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:302 ] .
 
 
 
-ABA:852 rdf:type owl:Class ;
+MBA:852 rdf:type owl:Class ;
 
         rdfs:label "Parvicellular reticular nucleus"@en ;
 
         nsu:synonym "PARN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:853 rdf:type owl:Class ;
+MBA:853 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, ventral part, molecular layer"@en ;
 
         nsu:synonym "SUBv-m"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:518 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:518 ] .
 
 
 
-ABA:854 rdf:type owl:Class ;
+MBA:854 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb, layer 2/3"@en ;
 
         nsu:synonym "SSp-ul2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:855 rdf:type owl:Class ;
+MBA:855 rdf:type owl:Class ;
 
         rdfs:label "retriculospinal tract"@en ;
 
         nsu:synonym "rst"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:856 rdf:type owl:Class ;
+MBA:856 rdf:type owl:Class ;
 
         rdfs:label "Thalamus, polymodal association cortex related"@en ;
 
         nsu:synonym "DORpm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:549 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:549 ] .
 
 
 
-ABA:857 rdf:type owl:Class ;
+MBA:857 rdf:type owl:Class ;
 
         rdfs:label "Visceral area, layer 6a"@en ;
 
         nsu:synonym "VISC6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:858 rdf:type owl:Class ;
+MBA:858 rdf:type owl:Class ;
 
         rdfs:label "ventral commissure of the spinal cord"@en ;
 
         nsu:synonym "vc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:932 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:932 ] .
 
 
 
-ABA:859 rdf:type owl:Class ;
+MBA:859 rdf:type owl:Class ;
 
         rdfs:label "Parasolitary nucleus"@en ;
 
         nsu:synonym "PAS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:86 rdf:type owl:Class ;
+MBA:86 rdf:type owl:Class ;
 
        rdfs:label "middle thalamic commissure"@en ;
 
        nsu:synonym "mtc"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:896 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:896 ] .
 
 
 
-ABA:860 rdf:type owl:Class ;
+MBA:860 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division, central lateral part"@en ;
 
         nsu:synonym "PBlc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:881 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:881 ] .
 
 
 
-ABA:861 rdf:type owl:Class ;
+MBA:861 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, ventral part, stratum radiatum"@en ;
 
         nsu:synonym "SUBv-sr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:518 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:518 ] .
 
 
 
-ABA:862 rdf:type owl:Class ;
+MBA:862 rdf:type owl:Class ;
 
         rdfs:label "Supplemental somatosensory area, layer 6a"@en ;
 
         nsu:synonym "SSs6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:863 rdf:type owl:Class ;
+MBA:863 rdf:type owl:Class ;
 
         rdfs:label "rubrospinal tract"@en ;
 
         nsu:synonym "rust"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:864 rdf:type owl:Class ;
+MBA:864 rdf:type owl:Class ;
 
         rdfs:label "Thalamus, sensory-motor cortex related"@en ;
 
         nsu:synonym "DORsm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:549 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:549 ] .
 
 
 
-ABA:865 rdf:type owl:Class ;
+MBA:865 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 4"@en ;
 
         nsu:synonym "SSp4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:866 rdf:type owl:Class ;
+MBA:866 rdf:type owl:Class ;
 
         rdfs:label "ventral spinocerebellar tract"@en ;
 
         nsu:synonym "sctv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:326 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:326 ] .
 
 
 
-ABA:867 rdf:type owl:Class ;
+MBA:867 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus"@en ;
 
         nsu:synonym "PB"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1132 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1132 ] .
 
 
 
-ABA:868 rdf:type owl:Class ;
+MBA:868 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division, dorsal lateral part"@en ;
 
         nsu:synonym "PBld"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:881 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:881 ] .
 
 
 
-ABA:869 rdf:type owl:Class ;
+MBA:869 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 4"@en ;
 
         nsu:synonym "VISpl4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:87 rdf:type owl:Class ;
+MBA:87 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, parvicellular division, medial parvicellular part, dorsal zone"@en ;
 
        nsu:synonym "PVHmpd"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:94 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:94 ] .
 
 
 
-ABA:870 rdf:type owl:Class ;
+MBA:870 rdf:type owl:Class ;
 
         rdfs:label "Subiculum, ventral part, pyramidal layer"@en ;
 
         nsu:synonym "SUBv-sp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:518 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:518 ] .
 
 
 
-ABA:871 rdf:type owl:Class ;
+MBA:871 rdf:type owl:Class ;
 
         rdfs:label "spinothalamic tract"@en ;
 
         nsu:synonym "sst"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:872 rdf:type owl:Class ;
+MBA:872 rdf:type owl:Class ;
 
         rdfs:label "Dorsal nucleus raphe"@en ;
 
         nsu:synonym "DR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:165 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:165 ] .
 
 
 
-ABA:873 rdf:type owl:Class ;
+MBA:873 rdf:type owl:Class ;
 
         rdfs:label "Supplemental somatosensory area, layer 1"@en ;
 
         nsu:synonym "SSs1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:874 rdf:type owl:Class ;
+MBA:874 rdf:type owl:Class ;
 
         rdfs:label "Parabigeminal nucleus"@en ;
 
         nsu:synonym "PBG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:339 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:339 ] .
 
 
 
-ABA:875 rdf:type owl:Class ;
+MBA:875 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division, external lateral part"@en ;
 
         nsu:synonym "PBle"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:881 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:881 ] .
 
 
 
-ABA:876 rdf:type owl:Class ;
+MBA:876 rdf:type owl:Class ;
 
         rdfs:label "accessory optic tract"@en ;
 
         nsu:synonym "aot"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:877 rdf:type owl:Class ;
+MBA:877 rdf:type owl:Class ;
 
         rdfs:label "tectospinal pathway"@en ;
 
         nsu:synonym "tsp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:878 rdf:type owl:Class ;
+MBA:878 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, mouth, layer 1"@en ;
 
         nsu:synonym "SSp-m1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:879 rdf:type owl:Class ;
+MBA:879 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, dorsal part"@en ;
 
         nsu:synonym "RSPd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:254 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:254 ] .
 
 
 
-ABA:88 rdf:type owl:Class ;
+MBA:88 rdf:type owl:Class ;
 
        rdfs:label "Anterior hypothalamic nucleus"@en ;
 
        nsu:synonym "AHN"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:880 rdf:type owl:Class ;
+MBA:880 rdf:type owl:Class ;
 
         rdfs:label "Dorsal tegmental nucleus"@en ;
 
         nsu:synonym "DTN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:881 rdf:type owl:Class ;
+MBA:881 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division"@en ;
 
         nsu:synonym "PBl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:867 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:867 ] .
 
 
 
-ABA:882 rdf:type owl:Class ;
+MBA:882 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area, Layer 6b"@en ;
 
         nsu:synonym "MOp6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:985 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:985 ] .
 
 
 
-ABA:883 rdf:type owl:Class ;
+MBA:883 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division, superior lateral part"@en ;
 
         nsu:synonym "PBls"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:881 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:881 ] .
 
 
 
-ABA:884 rdf:type owl:Class ;
+MBA:884 rdf:type owl:Class ;
 
         rdfs:label "amygdalar capsule"@en ;
 
         nsu:synonym "amc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:885 rdf:type owl:Class ;
+MBA:885 rdf:type owl:Class ;
 
         rdfs:label "terminal nerve"@en ;
 
         nsu:synonym "tn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:886 rdf:type owl:Class ;
+MBA:886 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, ventral part"@en ;
 
         nsu:synonym "RSPv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:254 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:254 ] .
 
 
 
-ABA:887 rdf:type owl:Class ;
+MBA:887 rdf:type owl:Class ;
 
         rdfs:label "Efferent cochlear group"@en ;
 
         nsu:synonym "ECO"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:888 rdf:type owl:Class ;
+MBA:888 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area, layer 2/3"@en ;
 
         nsu:synonym "PERI2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:922 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:922 ] .
 
 
 
-ABA:889 rdf:type owl:Class ;
+MBA:889 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 6a"@en ;
 
         nsu:synonym "SSp-n6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:89 rdf:type owl:Class ;
+MBA:89 rdf:type owl:Class ;
 
        rdfs:label "rhinocele"@en ;
 
        nsu:synonym "RC"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:81 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:81 ] .
 
 
 
-ABA:890 rdf:type owl:Class ;
+MBA:890 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, medial division"@en ;
 
         nsu:synonym "PBm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:867 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:867 ] .
 
 
 
-ABA:891 rdf:type owl:Class ;
+MBA:891 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, lateral division, ventral lateral part"@en ;
 
         nsu:synonym "PBlv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:881 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:881 ] .
 
 
 
-ABA:892 rdf:type owl:Class ;
+MBA:892 rdf:type owl:Class ;
 
         rdfs:label "ansa peduncularis"@en ;
 
         nsu:synonym "apd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:893 rdf:type owl:Class ;
+MBA:893 rdf:type owl:Class ;
 
         rdfs:label "Supplemental somatosensory area, layer 6b"@en ;
 
         nsu:synonym "SSs6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:378 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:378 ] .
 
 
 
-ABA:894 rdf:type owl:Class ;
+MBA:894 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part"@en ;
 
         nsu:synonym "RSPagl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:254 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:254 ] .
 
 
 
-ABA:895 rdf:type owl:Class ;
+MBA:895 rdf:type owl:Class ;
 
         rdfs:label "Ectorhinal area"@en ;
 
         nsu:synonym "ECT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:896 rdf:type owl:Class ;
+MBA:896 rdf:type owl:Class ;
 
         rdfs:label "thalamus related"@en ;
 
         nsu:synonym "lfbst"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:983 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:983 ] .
 
 
 
-ABA:897 rdf:type owl:Class ;
+MBA:897 rdf:type owl:Class ;
 
         rdfs:label "Visceral area, layer 1"@en ;
 
         nsu:synonym "VISC1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:677 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:677 ] .
 
 
 
-ABA:898 rdf:type owl:Class ;
+MBA:898 rdf:type owl:Class ;
 
         rdfs:label "Pontine central gray"@en ;
 
         nsu:synonym "PCG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:899 rdf:type owl:Class ;
+MBA:899 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, medial division, external medial part"@en ;
 
         nsu:synonym "PBme"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:890 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:890 ] .
 
 
 
-ABA:9 rdf:type owl:Class ;
+MBA:9 rdf:type owl:Class ;
 
       rdfs:label "Primary somatosensory area, trunk, layer 6a"@en ;
 
       nsu:synonym "SSp-tr6a"@en ;
 
-      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:361 ] .
+      rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:361 ] .
 
 
 
-ABA:90 rdf:type owl:Class ;
+MBA:90 rdf:type owl:Class ;
 
        rdfs:label "Nucleus of the lateral lemniscus, horizontal part"@en ;
 
        nsu:synonym "NLLh"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:612 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:612 ] .
 
 
 
-ABA:900 rdf:type owl:Class ;
+MBA:900 rdf:type owl:Class ;
 
         rdfs:label "anterior commissure, olfactory limb"@en ;
 
         nsu:synonym "aco"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:840 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:840 ] .
 
 
 
-ABA:901 rdf:type owl:Class ;
+MBA:901 rdf:type owl:Class ;
 
         rdfs:label "trigeminal nerve"@en ;
 
         nsu:synonym "Vn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:902 rdf:type owl:Class ;
+MBA:902 rdf:type owl:Class ;
 
         rdfs:label "Posterolateral visual area, layer 5"@en ;
 
         nsu:synonym "VISpl5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:425 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:425 ] .
 
 
 
-ABA:903 rdf:type owl:Class ;
+MBA:903 rdf:type owl:Class ;
 
         rdfs:label "External cuneate nucleus"@en ;
 
         nsu:synonym "ECU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:386 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:386 ] .
 
 
 
-ABA:904 rdf:type owl:Class ;
+MBA:904 rdf:type owl:Class ;
 
         rdfs:label "Medial septal complex"@en ;
 
         nsu:synonym "MSC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:826 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:826 ] .
 
 
 
-ABA:905 rdf:type owl:Class ;
+MBA:905 rdf:type owl:Class ;
 
         rdfs:label "Anterolateral visual area, layer 2/3"@en ;
 
         nsu:synonym "VISal2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:402 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:402 ] .
 
 
 
-ABA:906 rdf:type owl:Class ;
+MBA:906 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part, layer 6a"@en ;
 
         nsu:synonym "RSPagl6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:894 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:894 ] .
 
 
 
-ABA:907 rdf:type owl:Class ;
+MBA:907 rdf:type owl:Class ;
 
         rdfs:label "Paracentral nucleus"@en ;
 
         nsu:synonym "PCN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:51 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:51 ] .
 
 
 
-ABA:908 rdf:type owl:Class ;
+MBA:908 rdf:type owl:Class ;
 
         rdfs:label "anterior commissure, temporal limb"@en ;
 
         nsu:synonym "act"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:909 rdf:type owl:Class ;
+MBA:909 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area"@en ;
 
         nsu:synonym "ENT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:822 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:822 ] .
 
 
 
-ABA:91 rdf:type owl:Class ;
+MBA:91 rdf:type owl:Class ;
 
        rdfs:label "Interposed nucleus"@en ;
 
        nsu:synonym "IP"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:519 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:519 ] .
 
 
 
-ABA:910 rdf:type owl:Class ;
+MBA:910 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, medial part, layer 6a"@en ;
 
         nsu:synonym "ORBm6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:731 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:731 ] .
 
 
 
-ABA:911 rdf:type owl:Class ;
+MBA:911 rdf:type owl:Class ;
 
         rdfs:label "trochlear nerve"@en ;
 
         nsu:synonym "IVn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:912 rdf:type owl:Class ;
+MBA:912 rdf:type owl:Class ;
 
         rdfs:label "Lingula (I)"@en ;
 
         nsu:synonym "LING"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:913 rdf:type owl:Class ;
+MBA:913 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 4"@en ;
 
         nsu:synonym "VIS4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:914 rdf:type owl:Class ;
+MBA:914 rdf:type owl:Class ;
 
         rdfs:label "Posterodorsal preoptic nucleus"@en ;
 
         nsu:synonym "PD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:141 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:141 ] .
 
 
 
-ABA:915 rdf:type owl:Class ;
+MBA:915 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, medial division, medial medial part"@en ;
 
         nsu:synonym "PBmm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:890 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:890 ] .
 
 
 
-ABA:916 rdf:type owl:Class ;
+MBA:916 rdf:type owl:Class ;
 
         rdfs:label "brachium of the superior colliculus"@en ;
 
         nsu:synonym "bsc"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:848 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:848 ] .
 
 
 
-ABA:917 rdf:type owl:Class ;
+MBA:917 rdf:type owl:Class ;
 
         rdfs:label "vagus nerve"@en ;
 
         nsu:synonym "Xn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:918 rdf:type owl:Class ;
+MBA:918 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part"@en ;
 
         nsu:synonym "ENTl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:909 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:909 ] .
 
 
 
-ABA:919 rdf:type owl:Class ;
+MBA:919 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, dorsal part, layer 6a"@en ;
 
         nsu:synonym "ACAd6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:39 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:39 ] .
 
 
 
-ABA:92 rdf:type owl:Class ;
+MBA:92 rdf:type owl:Class ;
 
        rdfs:label "Entorhinal area, lateral part, layer 4"@en ;
 
        nsu:synonym "ENTl4"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:920 rdf:type owl:Class ;
+MBA:920 rdf:type owl:Class ;
 
         rdfs:label "Central lobule"@en ;
 
         nsu:synonym "CENT"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:921 rdf:type owl:Class ;
+MBA:921 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, layer 5"@en ;
 
         nsu:synonym "SSp5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:322 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:322 ] .
 
 
 
-ABA:922 rdf:type owl:Class ;
+MBA:922 rdf:type owl:Class ;
 
         rdfs:label "Perirhinal area"@en ;
 
         nsu:synonym "PERI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:923 rdf:type owl:Class ;
+MBA:923 rdf:type owl:Class ;
 
         rdfs:label "Parabrachial nucleus, medial division, ventral medial part"@en ;
 
         nsu:synonym "PBmv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:890 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:890 ] .
 
 
 
-ABA:924 rdf:type owl:Class ;
+MBA:924 rdf:type owl:Class ;
 
         rdfs:label "cerebal peduncle"@en ;
 
         nsu:synonym "cpd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:925 rdf:type owl:Class ;
+MBA:925 rdf:type owl:Class ;
 
         rdfs:label "ventral roots"@en ;
 
         nsu:synonym "vrt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:926 rdf:type owl:Class ;
+MBA:926 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, dorsal zone"@en ;
 
         nsu:synonym "ENTm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:909 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:909 ] .
 
 
 
-ABA:927 rdf:type owl:Class ;
+MBA:927 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, dorsal part, layer 6b"@en ;
 
         nsu:synonym "ACAd6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:39 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:39 ] .
 
 
 
-ABA:928 rdf:type owl:Class ;
+MBA:928 rdf:type owl:Class ;
 
         rdfs:label "Culmen"@en ;
 
         nsu:synonym "CUL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:929 rdf:type owl:Class ;
+MBA:929 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, nose, layer 6b"@en ;
 
         nsu:synonym "SSp-n6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:353 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:353 ] .
 
 
 
-ABA:93 rdf:type owl:Class ;
+MBA:93 rdf:type owl:Class ;
 
        rdfs:label "motor root of the trigeminal nerve"@en ;
 
        nsu:synonym "moV"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:901 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:901 ] .
 
 
 
-ABA:930 rdf:type owl:Class ;
+MBA:930 rdf:type owl:Class ;
 
         rdfs:label "Parafascicular nucleus"@en ;
 
         nsu:synonym "PF"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:51 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:51 ] .
 
 
 
-ABA:931 rdf:type owl:Class ;
+MBA:931 rdf:type owl:Class ;
 
         rdfs:label "Pontine gray"@en ;
 
         nsu:synonym "PG"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:987 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:987 ] .
 
 
 
-ABA:932 rdf:type owl:Class ;
+MBA:932 rdf:type owl:Class ;
 
         rdfs:label "cervicothalamic tract"@en ;
 
         nsu:synonym "cett"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:792 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:792 ] .
 
 
 
-ABA:933 rdf:type owl:Class ;
+MBA:933 rdf:type owl:Class ;
 
         rdfs:label "vestibulocochlear nerve"@en ;
 
         nsu:synonym "VIIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:934 rdf:type owl:Class ;
+MBA:934 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, medial part, ventral zone"@en ;
 
         nsu:synonym "ENTmv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:909 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:909 ] .
 
 
 
-ABA:935 rdf:type owl:Class ;
+MBA:935 rdf:type owl:Class ;
 
         rdfs:label "Anterior cingulate area, dorsal part, layer 1"@en ;
 
         nsu:synonym "ACAd1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:39 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:39 ] .
 
 
 
-ABA:936 rdf:type owl:Class ;
+MBA:936 rdf:type owl:Class ;
 
         rdfs:label "Declive (VI)"@en ;
 
         nsu:synonym "DEC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:937 rdf:type owl:Class ;
+MBA:937 rdf:type owl:Class ;
 
         rdfs:label "Visual areas, layer 5"@en ;
 
         nsu:synonym "VIS5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:669 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:669 ] .
 
 
 
-ABA:938 rdf:type owl:Class ;
+MBA:938 rdf:type owl:Class ;
 
         rdfs:label "Paragigantocellular reticular nucleus"@en ;
 
         nsu:synonym "PGRN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:939 rdf:type owl:Class ;
+MBA:939 rdf:type owl:Class ;
 
         rdfs:label "Nucleus ambiguus, dorsal division"@en ;
 
         nsu:synonym "AMBd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:135 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:135 ] .
 
 
 
-ABA:94 rdf:type owl:Class ;
+MBA:94 rdf:type owl:Class ;
 
        rdfs:label "Paraventricular hypothalamic nucleus, parvicellular division"@en ;
 
        nsu:synonym "PVHp"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:38 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:38 ] .
 
 
 
-ABA:940 rdf:type owl:Class ;
+MBA:940 rdf:type owl:Class ;
 
         rdfs:label "cingulum bundle"@en ;
 
         nsu:synonym "cing"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:768 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:768 ] .
 
 
 
-ABA:941 rdf:type owl:Class ;
+MBA:941 rdf:type owl:Class ;
 
         rdfs:label "vestibulospinal pathway"@en ;
 
         nsu:synonym "vsp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1000 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1000 ] .
 
 
 
-ABA:942 rdf:type owl:Class ;
+MBA:942 rdf:type owl:Class ;
 
         rdfs:label "Endopiriform nucleus"@en ;
 
         nsu:synonym "EP"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:703 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:703 ] .
 
 
 
-ABA:943 rdf:type owl:Class ;
+MBA:943 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area, Layer 2/3"@en ;
 
         nsu:synonym "MOp2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:985 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:985 ] .
 
 
 
-ABA:944 rdf:type owl:Class ;
+MBA:944 rdf:type owl:Class ;
 
         rdfs:label "Folium-tuber vermis (VII)"@en ;
 
         nsu:synonym "FOTU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:945 rdf:type owl:Class ;
+MBA:945 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, upper limb, layer 6a"@en ;
 
         nsu:synonym "SSp-ul6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:369 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:369 ] .
 
 
 
-ABA:946 rdf:type owl:Class ;
+MBA:946 rdf:type owl:Class ;
 
         rdfs:label "Posterior hypothalamic nucleus"@en ;
 
         nsu:synonym "PH"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:947 rdf:type owl:Class ;
+MBA:947 rdf:type owl:Class ;
 
         rdfs:label "Somatomotor areas, Layer 6b"@en ;
 
         nsu:synonym "MO6b"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:948 rdf:type owl:Class ;
+MBA:948 rdf:type owl:Class ;
 
         rdfs:label "cochlear nerve"@en ;
 
         nsu:synonym "cVIIIn"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:933 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:933 ] .
 
 
 
-ABA:949 rdf:type owl:Class ;
+MBA:949 rdf:type owl:Class ;
 
         rdfs:label "vomeronasal nerve"@en ;
 
         nsu:synonym "von"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:967 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:967 ] .
 
 
 
-ABA:95 rdf:type owl:Class ;
+MBA:95 rdf:type owl:Class ;
 
        rdfs:label "Agranular insular area"@en ;
 
        nsu:synonym "AI"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:950 rdf:type owl:Class ;
+MBA:950 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, mouth, layer 4"@en ;
 
         nsu:synonym "SSp-m4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:951 rdf:type owl:Class ;
+MBA:951 rdf:type owl:Class ;
 
         rdfs:label "Pyramus (VIII)"@en ;
 
         nsu:synonym "PYR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:952 rdf:type owl:Class ;
+MBA:952 rdf:type owl:Class ;
 
         rdfs:label "Endopiriform nucleus, dorsal part"@en ;
 
         nsu:synonym "EPd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:942 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:942 ] .
 
 
 
-ABA:953 rdf:type owl:Class ;
+MBA:953 rdf:type owl:Class ;
 
         rdfs:label "Pineal body"@en ;
 
         nsu:synonym "PIN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:958 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:958 ] .
 
 
 
-ABA:954 rdf:type owl:Class ;
+MBA:954 rdf:type owl:Class ;
 
         rdfs:label "Primary auditory area, layer 6a"@en ;
 
         nsu:synonym "AUDp6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1002 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1002 ] .
 
 
 
-ABA:955 rdf:type owl:Class ;
+MBA:955 rdf:type owl:Class ;
 
         rdfs:label "Lateral reticular nucleus, magnocellular part"@en ;
 
         nsu:synonym "LRNm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:235 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:235 ] .
 
 
 
-ABA:956 rdf:type owl:Class ;
+MBA:956 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum, anterior forceps"@en ;
 
         nsu:synonym "fa"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:957 rdf:type owl:Class ;
+MBA:957 rdf:type owl:Class ;
 
         rdfs:label "Uvula (IX)"@en ;
 
         nsu:synonym "UVU"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:958 rdf:type owl:Class ;
+MBA:958 rdf:type owl:Class ;
 
         rdfs:label "Epithalamus"@en ;
 
         nsu:synonym "EPI"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:856 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:856 ] .
 
 
 
-ABA:959 rdf:type owl:Class ;
+MBA:959 rdf:type owl:Class ;
 
         rdfs:label "Ventral auditory area, layer 1"@en ;
 
         nsu:synonym "AUDv1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:96 rdf:type owl:Class ;
+MBA:96 rdf:type owl:Class ;
 
        rdfs:label "Dorsal cochlear nucleus"@en ;
 
        nsu:synonym "DCO"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:607 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:607 ] .
 
 
 
-ABA:960 rdf:type owl:Class ;
+MBA:960 rdf:type owl:Class ;
 
         rdfs:label "cerebellum related fiber tracts"@en ;
 
         nsu:synonym "cbf"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1009 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1009 ] .
 
 
 
-ABA:961 rdf:type owl:Class ;
+MBA:961 rdf:type owl:Class ;
 
         rdfs:label "Piriform area"@en ;
 
         nsu:synonym "PIR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:698 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:698 ] .
 
 
 
-ABA:962 rdf:type owl:Class ;
+MBA:962 rdf:type owl:Class ;
 
         rdfs:label "Secondary motor area, layer 2/3"@en ;
 
         nsu:synonym "MOs2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:993 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:993 ] .
 
 
 
-ABA:963 rdf:type owl:Class ;
+MBA:963 rdf:type owl:Class ;
 
         rdfs:label "Lateral reticular nucleus, parvicellular part"@en ;
 
         nsu:synonym "LRNp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:235 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:235 ] .
 
 
 
-ABA:964 rdf:type owl:Class ;
+MBA:964 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum, extreme capsule"@en ;
 
         nsu:synonym "ee"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:965 rdf:type owl:Class ;
+MBA:965 rdf:type owl:Class ;
 
         rdfs:label "Retrosplenial area, lateral agranular part, layer 2/3"@en ;
 
         nsu:synonym "RSPagl2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:894 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:894 ] .
 
 
 
-ABA:966 rdf:type owl:Class ;
+MBA:966 rdf:type owl:Class ;
 
         rdfs:label "Endopiriform nucleus, ventral part"@en ;
 
         nsu:synonym "EPv"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:942 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:942 ] .
 
 
 
-ABA:967 rdf:type owl:Class ;
+MBA:967 rdf:type owl:Class ;
 
         rdfs:label "cranial nerves"@en ;
 
         nsu:synonym "cm"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1009 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1009 ] .
 
 
 
-ABA:968 rdf:type owl:Class ;
+MBA:968 rdf:type owl:Class ;
 
         rdfs:label "Nodulus (X)"@en ;
 
         nsu:synonym "NOD"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:645 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:645 ] .
 
 
 
-ABA:969 rdf:type owl:Class ;
+MBA:969 rdf:type owl:Class ;
 
         rdfs:label "Orbital area, ventrolateral part, layer 1"@en ;
 
         nsu:synonym "ORBvl1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:746 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:746 ] .
 
 
 
-ABA:97 rdf:type owl:Class ;
+MBA:97 rdf:type owl:Class ;
 
        rdfs:label "Temporal association areas, layer 1"@en ;
 
        nsu:synonym "TEa1"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:541 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:541 ] .
 
 
 
-ABA:970 rdf:type owl:Class ;
+MBA:970 rdf:type owl:Class ;
 
         rdfs:label "Paragigantocellular reticular nucleus, dorsal part"@en ;
 
         nsu:synonym "PGRNd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:938 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:938 ] .
 
 
 
-ABA:971 rdf:type owl:Class ;
+MBA:971 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum, posterior forceps"@en ;
 
         nsu:synonym "fp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:972 rdf:type owl:Class ;
+MBA:972 rdf:type owl:Class ;
 
         rdfs:label "Prelimbic area"@en ;
 
         nsu:synonym "PL"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:315 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:315 ] .
 
 
 
-ABA:973 rdf:type owl:Class ;
+MBA:973 rdf:type owl:Class ;
 
         rdfs:label "Lateral visual area, layer 2/3"@en ;
 
         nsu:synonym "VISl23"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:409 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:409 ] .
 
 
 
-ABA:974 rdf:type owl:Class ;
+MBA:974 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, mouth, layer 5"@en ;
 
         nsu:synonym "SSp-m5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:345 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:345 ] .
 
 
 
-ABA:975 rdf:type owl:Class ;
+MBA:975 rdf:type owl:Class ;
 
         rdfs:label "Edinger-Westphal nucleus"@en ;
 
         nsu:synonym "EW"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:323 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:323 ] .
 
 
 
-ABA:976 rdf:type owl:Class ;
+MBA:976 rdf:type owl:Class ;
 
         rdfs:label "Lobule II"@en ;
 
         nsu:synonym "CENT2"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:920 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:920 ] .
 
 
 
-ABA:977 rdf:type owl:Class ;
+MBA:977 rdf:type owl:Class ;
 
         rdfs:label "Ectorhinal area/Layer 6a"@en ;
 
         nsu:synonym "ECT6a"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:895 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:895 ] .
 
 
 
-ABA:978 rdf:type owl:Class ;
+MBA:978 rdf:type owl:Class ;
 
         rdfs:label "Paragigantocellular reticular nucleus, lateral part"@en ;
 
         nsu:synonym "PGRNl"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:938 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:938 ] .
 
 
 
-ABA:979 rdf:type owl:Class ;
+MBA:979 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum, rostrum"@en ;
 
         nsu:synonym "ccr"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:98 rdf:type owl:Class ;
+MBA:98 rdf:type owl:Class ;
 
        rdfs:label "subependymal zone"@en ;
 
        nsu:synonym "SEZ"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:81 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:81 ] .
 
 
 
-ABA:980 rdf:type owl:Class ;
+MBA:980 rdf:type owl:Class ;
 
         rdfs:label "Dorsal premammillary nucleus"@en ;
 
         nsu:synonym "PMd"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:467 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:467 ] .
 
 
 
-ABA:981 rdf:type owl:Class ;
+MBA:981 rdf:type owl:Class ;
 
         rdfs:label "Primary somatosensory area, barrel field, layer 1"@en ;
 
         nsu:synonym "SSp-bfd1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:329 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:329 ] .
 
 
 
-ABA:982 rdf:type owl:Class ;
+MBA:982 rdf:type owl:Class ;
 
         rdfs:label "Fasciola cinerea"@en ;
 
         nsu:synonym "FC"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1080 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1080 ] .
 
 
 
-ABA:983 rdf:type owl:Class ;
+MBA:983 rdf:type owl:Class ;
 
         rdfs:label "lateral forebrain bundle system"@en ;
 
         nsu:synonym "lfbs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1009 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1009 ] .
 
 
 
-ABA:984 rdf:type owl:Class ;
+MBA:984 rdf:type owl:Class ;
 
         rdfs:label "Lobule III"@en ;
 
         nsu:synonym "CENT3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:920 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:920 ] .
 
 
 
-ABA:985 rdf:type owl:Class ;
+MBA:985 rdf:type owl:Class ;
 
         rdfs:label "Primary motor area"@en ;
 
         nsu:synonym "MOp"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:986 rdf:type owl:Class ;
+MBA:986 rdf:type owl:Class ;
 
         rdfs:label "corpus callosum, splenium"@en ;
 
         nsu:synonym "ccs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:776 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:776 ] .
 
 
 
-ABA:987 rdf:type owl:Class ;
+MBA:987 rdf:type owl:Class ;
 
         rdfs:label "Pons, motor related"@en ;
 
         nsu:synonym "P-mot"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:771 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:771 ] .
 
 
 
-ABA:988 rdf:type owl:Class ;
+MBA:988 rdf:type owl:Class ;
 
         rdfs:label "Ectorhinal area/Layer 5"@en ;
 
         nsu:synonym "ECT5"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:895 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:895 ] .
 
 
 
-ABA:989 rdf:type owl:Class ;
+MBA:989 rdf:type owl:Class ;
 
         rdfs:label "Fastigial nucleus"@en ;
 
         nsu:synonym "FN"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:519 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:519 ] .
 
 
 
-ABA:99 rdf:type owl:Class ;
+MBA:99 rdf:type owl:Class ;
 
        rdfs:label "Nucleus of the lateral lemniscus, ventral part"@en ;
 
        nsu:synonym "NLLv"@en ;
 
-       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:612 ] .
+       rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:612 ] .
 
 
 
-ABA:990 rdf:type owl:Class ;
+MBA:990 rdf:type owl:Class ;
 
         rdfs:label "Ventral auditory area, layer 4"@en ;
 
         nsu:synonym "AUDv4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1018 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1018 ] .
 
 
 
-ABA:991 rdf:type owl:Class ;
+MBA:991 rdf:type owl:Class ;
 
         rdfs:label "medial forebrain bundle system"@en ;
 
         nsu:synonym "mfbs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:1009 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:1009 ] .
 
 
 
-ABA:992 rdf:type owl:Class ;
+MBA:992 rdf:type owl:Class ;
 
         rdfs:label "Lobule IV"@en ;
 
         nsu:synonym "CUL4"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:928 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:928 ] .
 
 
 
-ABA:993 rdf:type owl:Class ;
+MBA:993 rdf:type owl:Class ;
 
         rdfs:label "Secondary motor area"@en ;
 
         nsu:synonym "MOs"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:500 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:500 ] .
 
 
 
-ABA:994 rdf:type owl:Class ;
+MBA:994 rdf:type owl:Class ;
 
         rdfs:label "corticobulbar tract"@en ;
 
         nsu:synonym "cbt"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:784 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:784 ] .
 
 
 
-ABA:995 rdf:type owl:Class ;
+MBA:995 rdf:type owl:Class ;
 
         rdfs:label "Paramedian reticular nucleus"@en ;
 
         nsu:synonym "PMR"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:370 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:370 ] .
 
 
 
-ABA:996 rdf:type owl:Class ;
+MBA:996 rdf:type owl:Class ;
 
         rdfs:label "Agranular insular area, dorsal part, layer 1"@en ;
 
         nsu:synonym "AId1"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:104 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:104 ] .
 
 
 
-ABA:997 rdf:type owl:Class ;
+MBA:997 rdf:type owl:Class ;
 
         rdfs:label "Brain"@en ;
 
@@ -12053,63 +12053,63 @@ ABA:997 rdf:type owl:Class ;
 
 
 
-ABA:998 rdf:type owl:Class ;
+MBA:998 rdf:type owl:Class ;
 
         rdfs:label "Fundus of striatum"@en ;
 
         nsu:synonym "FS"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:493 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:493 ] .
 
 
 
-ABA:999 rdf:type owl:Class ;
+MBA:999 rdf:type owl:Class ;
 
         rdfs:label "Entorhinal area, lateral part, layer 2/3"@en ;
 
         nsu:synonym "ENTl2/3"@en ;
 
-        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom ABA:918 ] .
+        rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty nsu:part_of ; owl:someValuesFrom MBA:918 ] .
 
 
 
-ABA:1146 rdf:type owl:Class ;
+MBA:1146 rdf:type owl:Class ;
 
          rdfs:label "forebrain"@en .
 
 
 
-ABA:1147 rdf:type owl:Class ;
+MBA:1147 rdf:type owl:Class ;
 
          rdfs:label "hippocampus"@en .
 
 
 
-ABA:1148 rdf:type owl:Class ;
+MBA:1148 rdf:type owl:Class ;
 
          rdfs:label "medial-cortex"@en .
 
 
 
-ABA:1149 rdf:type owl:Class ;
+MBA:1149 rdf:type owl:Class ;
 
          rdfs:label "frontal-cortex"@en .
 
 
 
-ABA:1150 rdf:type owl:Class ;
+MBA:1150 rdf:type owl:Class ;
 
          rdfs:label "caudal-cortex"@en .
 
 
 
-ABA:1151 rdf:type owl:Class ;
+MBA:1151 rdf:type owl:Class ;
 
          rdfs:label "somatosensory cortex"@en .
 
 
 
-ABA:1152 rdf:type owl:Class ;
+MBA:1152 rdf:type owl:Class ;
 
          rdfs:label "CA1"@en .
 


### PR DESCRIPTION
Pull request to normalize the prefix we use for the Allen mouse brain atlas.
